### PR TITLE
[`VHead`] Fix slow convergence issue

### DIFF
--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -84,6 +84,24 @@ class VHeadModelTester(BaseModelTester, unittest.TestCase):
             model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
             self.assertTrue(hasattr(model, "v_head"))
     
+    def test_vhead_nb_classes(self):
+        r"""
+        Test if the v-head has the correct shape
+        """
+        for model_name in self.all_model_names:
+            model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
+            self.assertTrue(model.v_head.summary.weight.shape[0] == 1)
+    
+    def test_vhead_init_random(self):
+        r"""
+        Test if the v-head has been randomly initialized. 
+        We can check that by making sure the bias is different 
+        than zeros by default.
+        """
+        for model_name in self.all_model_names:
+            model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
+            self.assertFalse(torch.allclose(model.v_head.summary.bias, torch.zeros_like(model.v_head.summary.bias))) 
+    
     def test_vhead_not_str(self):
         r"""
         Test if the v-head is added to the model succesfully

--- a/trl/models/modeling_vhead.py
+++ b/trl/models/modeling_vhead.py
@@ -26,11 +26,6 @@ class ValueHead(nn.Module):
             summary_dropout_prob = kwargs.pop("summary_dropout_prob", 0.1)
         else:
             summary_dropout_prob = config.summary_dropout_prob
-
-        if hasattr(config, "summary_proj_to_labels") and config.summary_proj_to_labels and config.num_labels > 0:
-            num_classes = config.num_labels
-        else:
-            num_classes = config.hidden_size
         
         self.dropout = nn.Dropout(summary_dropout_prob) if summary_dropout_prob else nn.Identity()
 
@@ -40,7 +35,7 @@ class ValueHead(nn.Module):
         else:
             hidden_size = config.hidden_size
 
-        self.summary = nn.Linear(hidden_size, num_classes)
+        self.summary = nn.Linear(hidden_size, 1)
 
         self.flatten = nn.Flatten()
 

--- a/trl/models/modeling_vhead.py
+++ b/trl/models/modeling_vhead.py
@@ -75,6 +75,7 @@ class AutoModelForCausalLMWithValueHead(PreTrainedModelWrapper):
     supported_args = (
         "summary_dropout_prob",
         "v_head_initializer_range",
+        "v_head_init_strategy",
     )
 
     def __init__(self, pretrained_model, **kwargs):
@@ -92,10 +93,15 @@ class AutoModelForCausalLMWithValueHead(PreTrainedModelWrapper):
         r"""
         We initialize the weights of the value head.
         """
-        initializer_range = kwargs.pop("initializer_range", 0.2)
-
-        self.v_head.summary.weight.data.normal_(mean=0.0, std=initializer_range)
-        self.v_head.summary.bias.data.zero_()
+        initializer_range = kwargs.pop("v_head_initializer_range", 0.2)
+        # random init by default
+        init_strategy = kwargs.pop("v_head_init_strategy", None)
+        if init_strategy is None:
+            # do nothing
+            pass
+        elif init_strategy == "normal":
+            self.v_head.summary.weight.data.normal_(mean=0.0, std=initializer_range)
+            self.v_head.summary.bias.data.zero_()
     
     def forward(
         self,

--- a/trl/ppo.py
+++ b/trl/ppo.py
@@ -260,8 +260,6 @@ class PPOTrainer:
 
         ratio = torch.exp(logprob - old_logprobs)
 
-        if len(ratio.shape) == 2:
-            ratio = ratio.unsqueeze(-1)
 
         pg_losses = -advantages * ratio
         pg_losses2 = -advantages * torch.clamp(ratio,


### PR DESCRIPTION
# What does this PR do?

This PR fixes a behaviour that we have encountered with #53 - for some reason the aforementioned PR lead to having models that does behave exactly similarly as the reference model, for the policy metrics, more precisely the `kl`, `policykl` `approxkl` were much more different than before. 

The issue seemed to be related to the initialization strategy of the VHead model. In #53 `_init_weights` method was introduced for consistency with `transformers` and to give users the possibility to tweak the initialization strategy of the VHead module. 

This PR fixes the behaviour precised above, by randomly initilazing the weights by default

cc @lvwerra 