### PR TITLE
[core] refactor `step` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ device = ppo_trainer.accelerator.device
 
 # define a reward for response
 # (this could be any reward such as human feedback or output from another model)
-reward = [torch.tensor(1.0).to(device)]
+reward = [torch.tensor(1.0)]
 
 # train model for one step with ppo
 train_stats = ppo_trainer.step([query_tensor[0].to(device)], [response_tensor[0].to(device)], reward)

--- a/examples/scripts/ppo-sentiment.py
+++ b/examples/scripts/ppo-sentiment.py
@@ -143,7 +143,7 @@ for epoch, batch in tqdm(enumerate(ppo_trainer.dataloader)):
     #### Compute sentiment score
     texts = [q + r for q,r in zip(batch['query'], batch['response'])]
     pipe_outputs = sentiment_pipe(texts, **sent_kwargs)
-    rewards = [torch.tensor(output[1]["score"]).to(device) for output in pipe_outputs]
+    rewards = [torch.tensor([[output[1]["score"]]]) for output in pipe_outputs]
 
     #### Run PPO step 
     stats = ppo_trainer.step(query_tensors, response_tensors, rewards)


### PR DESCRIPTION
This PR adds a new safety checker inside `step` method to make sure the rewards are set on the correct device. Regarding the queries and the responses users should retrieve the dataloader from the trainer and use that instead as the device assignment is performed directly at the dataloader level. Since the reward is not part of the dataloader the device assignment needs to be performed manually.

This PR also adds inside the safety checker a new check. Before this PR if a user pass a reward tensor with a dimension different from 0 (e.g. `torch.tensor([1.0])`) it would break the training loop. Therefore now we force the reward tensor to be with the desired shape. We now also throw a value error if the dimension of the reward is > 1.

cc @lewtun @lvwerra @edbeeching 