### PR TITLE
Remove references to "listify_batch"

### DIFF
--- a/examples/notebooks/gpt2-sentiment-ppo-training.ipynb
+++ b/examples/notebooks/gpt2-sentiment-ppo-training.ipynb
@@ -74,7 +74,7 @@
     "\n",
     "from trl.gpt2 import GPT2HeadWithValueModel, respond_to_batch\n",
     "from trl.ppo import PPOTrainer\n",
-    "from trl.core import build_bert_batch_from_txt, listify_batch"
+    "from trl.core import build_bert_batch_from_txt"
    ]
   },
   {


### PR DESCRIPTION
The function "listify_batch" does not exist in "trl==0.0.3", and it will not be used later in this example