### PR TITLE
[API] Make `dataset` attribute optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,28 +71,9 @@ query_tensor = tokenizer.encode(query_txt, return_tensors="pt")
 
 # get model response
 response_tensor  = respond_to_batch(model_ref, query_tensor)
-response_txt = tokenizer.decode(response_tensor[0,:])
-
-# create a dummy dataset
-class DummyDataset(torch.utils.data.Dataset):
-    def __init__(self, query_data, response_data):
-        self.query_data = query_data
-        self.response_data = response_data
-
-    def __len__(self):
-        return len(self.query_data)
-
-    def __getitem__(self, idx):
-        return self.query_data[idx], self.response_data[idx]
-
-min_length = min(len(query_tensor[0]), len(response_tensor[0]))
-dummy_dataset = DummyDataset(
-    [query_tensor[:, :min_length].squeeze(0) for _ in range(2)],
-    [response_tensor[:, :min_length].squeeze(0) for _ in range(2)],
-)
 
 # create a ppo trainer
-ppo_trainer = PPOTrainer(ppo_config, model, model_ref, tokenizer, dummy_dataset)
+ppo_trainer = PPOTrainer(ppo_config, model, model_ref, tokenizer)
 device = ppo_trainer.accelerator.device
 
 # define a reward for response

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -342,3 +342,38 @@ class PPOTrainerTester(unittest.TestCase):
                 self.assertEqual(queries[i].shape, torch.Size([7]))
                 self.assertEqual(responses[i].size(), torch.Size([7]))
             break
+
+    def test_ppo_step_no_dataset(self):
+        """
+        Test if the training loop works fine without passing a dataset
+        """
+        query_txt = "This morning I went to the "
+        query_tensor = self.gpt2_tokenizer.encode(query_txt, return_tensors="pt")
+        self.ppo_config.batch_size = 1
+
+        response_tensor = respond_to_batch(self.gpt2_model, query_tensor)
+
+        # Check that this warns the user about batch size
+        with self.assertWarns(UserWarning):
+            ppo_trainer = PPOTrainer(
+                config=self.ppo_config,
+                model=self.gpt2_model,
+                ref_model=self.gpt2_model_ref,
+                tokenizer=self.gpt2_tokenizer,
+            )
+        # train model with ppo
+        reward = [torch.tensor([1.0])]
+        # train model - this should work fine
+        train_stats = ppo_trainer.step([query_tensor[0]], [response_tensor[0]], reward)
+
+        # check gradients
+        for name, param in ppo_trainer.model.named_parameters():
+            self.assertTrue(param.grad is not None, f"Parameter {name} has no gradient")
+
+        # ref model should not be trained
+        for name, param in ppo_trainer.ref_model.named_parameters():
+            self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
+
+        # check train stats
+        for stat in EXPECTED_STATS:
+            self.assertTrue(stat in train_stats, f"Train stats should contain {stat}")


### PR DESCRIPTION
# What does this PR do?

This PR makes the `dataset` attribute optional for the `PPOTrainer` to simplify the API. Currently one needs to create a Dataset class in order to initialize the `PPOTrainer`. We can make things simpler by making this attribute optional. 
Though the `PPOTrainer` training loop relies heavily on the `config.batch_size` attribute, I suggest to warn users to make sure that they have set `config.batch_size` to the correct batch_size before running anything

Also updated and tested the script on the REAMDE

@lvwerra 