### PR TITLE
[core] Push `v_head` when using `AutoModelForCausalLMWithValueHead`

### DIFF
--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -67,3 +67,11 @@ from transformers import AutoModelForCausalLM
 
 model = AutoModelForCausalLM.from_pretrained("my-fine-tuned-model-ppo")
 ```
+
+You can also load your model with `AutoModelForCausalLMWithValueHead` if you want to use the value head, for example to continue a training.
+
+```python
+from trl.model import AutoModelForCausalLMWithValueHead
+
+model = AutoModelForCausalLMWithValueHead.from_pretrained("my-fine-tuned-model-ppo")
+```

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -49,7 +49,7 @@ train_stats = ppo_trainer.step([query_tensor[0]], [response_tensor[0]], reward)
 
 In general, you would run steps 3-6 in a for-loop and run it on many diverse queries. You can find a more realistic examples in the examples section. 
 
-## How to use the model
+## How to use a trained model
 
 After training a `AutoModelForCausalLMWithValueHead`, you can directly use the model in `transformers`.
 ```python

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -48,3 +48,22 @@ train_stats = ppo_trainer.step([query_tensor[0]], [response_tensor[0]], reward)
 ```
 
 In general, you would run steps 3-6 in a for-loop and run it on many diverse queries. You can find a more realistic examples in the examples section. 
+
+## How to use the model
+
+After training a `AutoModelForCausalLMWithValueHead`, you can directly use the model in `transformers`.
+```python
+
+# .. Let's assume we have a trained model using `PPOTrainer` and `AutoModelForCausalLMWithValueHead`
+
+# push the model on the Hub
+model.push_to_hub("my-fine-tuned-model-ppo")
+
+# or save it locally
+model.save_pretrained("my-fine-tuned-model-ppo")
+
+# load the model from the Hub
+from transformers import AutoModelForCausalLM
+
+model = AutoModelForCausalLM.from_pretrained("my-fine-tuned-model-ppo")
+```

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -53,6 +53,24 @@ class BaseModelTester:
             for key in model_from_save.state_dict():
                 self.assertTrue(torch.allclose(model_from_save.state_dict()[key], model.state_dict()[key]))
 
+    def test_from_save_after_training(self):
+        """
+        Test if the model can be saved and loaded from a directory and get the same weights
+        Here we add the argument `resume_training=True` to the `from_pretrained` method
+        to load also the `v_head` weights.
+        """
+        for model_name in self.all_model_names:
+            model = self.trl_model_class.from_pretrained(model_name)
+
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                model.save_pretrained(tmp_dir)
+
+                model_from_save = self.trl_model_class.from_pretrained(tmp_dir, resume_training=True)
+
+            # Check if the weights are the same
+            for key in model_from_save.state_dict():
+                self.assertTrue(torch.allclose(model_from_save.state_dict()[key], model.state_dict()[key]))
+
     def test_from_save_transformers(self):
         """
         Test if the model can be saved and loaded using transformers and get the same weights

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -56,8 +56,6 @@ class BaseModelTester:
     def test_from_save_after_training(self):
         """
         Test if the model can be saved and loaded from a directory and get the same weights
-        Here we add the argument `resume_training=True` to the `from_pretrained` method
-        to load also the `v_head` weights.
         """
         for model_name in self.all_model_names:
             model = self.trl_model_class.from_pretrained(model_name)
@@ -65,7 +63,7 @@ class BaseModelTester:
             with tempfile.TemporaryDirectory() as tmp_dir:
                 model.save_pretrained(tmp_dir)
 
-                model_from_save = self.trl_model_class.from_pretrained(tmp_dir, resume_training=True)
+                model_from_save = self.trl_model_class.from_pretrained(tmp_dir)
 
             # Check if the weights are the same
             for key in model_from_save.state_dict():
@@ -208,9 +206,7 @@ class ValueHeadModelTester(BaseModelTester, unittest.TestCase):
             model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
             model.push_to_hub(model_name + "-ppo", use_auth_token=True)
 
-            model_from_pretrained = AutoModelForCausalLMWithValueHead.from_pretrained(
-                model_name + "-ppo", resume_training=True
-            )
+            model_from_pretrained = AutoModelForCausalLMWithValueHead.from_pretrained(model_name + "-ppo")
             # check all keys
             self.assertEqual(model.state_dict().keys(), model_from_pretrained.state_dict().keys())
 
@@ -219,6 +215,41 @@ class ValueHeadModelTester(BaseModelTester, unittest.TestCase):
                     torch.allclose(param, model_from_pretrained.state_dict()[name]),
                     f"Parameter {name} is not the same after push_to_hub and from_pretrained",
                 )
+
+    def test_from_save_transformers(self):
+        """
+        Test if the model can be saved and loaded using transformers and get the same weights.
+        We override the test of the super class to check if the weights are the same.
+        """
+        for model_name in self.all_model_names:
+            transformers_model = self.trl_model_class.transformers_parent_class.from_pretrained(model_name)
+
+            trl_model = self.trl_model_class.from_pretrained(model_name)
+
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                trl_model.save_pretrained(tmp_dir)
+                transformers_model_from_save = self.trl_model_class.transformers_parent_class.from_pretrained(tmp_dir)
+
+            # Check if the weights are the same
+            for key in transformers_model.state_dict():
+                self.assertTrue(
+                    torch.allclose(
+                        transformers_model_from_save.state_dict()[key], transformers_model.state_dict()[key]
+                    )
+                )
+
+            # Check if the trl model has the same keys as the transformers model
+            # except the v_head
+            for key in trl_model.state_dict():
+                if "v_head" not in key:
+                    self.assertTrue(key in transformers_model.state_dict())
+                    # check if the weights are the same
+                    self.assertTrue(torch.allclose(trl_model.state_dict()[key], transformers_model.state_dict()[key]))
+
+            # check if they have the same modules
+            self.assertTrue(
+                set(transformers_model_from_save.state_dict().keys()) == set(transformers_model.state_dict().keys())
+            )
 
 
 class ReferenceModelTest(unittest.TestCase):

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -28,6 +28,7 @@ ALL_CAUSAL_LM_MODELS = [
     "trl-internal-testing/tiny-random-OPTForCausalLM",
     "trl-internal-testing/tiny-random-BloomForCausalLM",
     "trl-internal-testing/tiny-random-GPT2LMHeadModel",
+    "trl-internal-testing/tiny-random-CodeGenForCausalLM-sharded",
 ]
 
 
@@ -204,7 +205,10 @@ class ValueHeadModelTester(BaseModelTester, unittest.TestCase):
     def test_push_to_hub(self):
         for model_name in self.all_model_names:
             model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
-            model.push_to_hub(model_name + "-ppo", use_auth_token=True)
+            if "sharded" in model_name:
+                model.push_to_hub(model_name + "-ppo", use_auth_token=True, max_shard_size="1MB")
+            else:
+                model.push_to_hub(model_name + "-ppo", use_auth_token=True)
 
             model_from_pretrained = AutoModelForCausalLMWithValueHead.from_pretrained(model_name + "-ppo")
             # check all keys

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -189,6 +189,8 @@ class PPOTrainerTester(unittest.TestCase):
         model = AutoModelForCausalLMWithValueHead.from_pretrained("gpt2")
         for name, param in ppo_trainer.ref_model.named_parameters():
             if "v_head" not in name:
+                name = name.replace("pretrained_model.", "")
+
                 self.assertTrue(
                     torch.allclose(param.cpu(), model.state_dict()[name].cpu()),
                     f"Parameter {name} has changed from the original model",

--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -94,8 +94,8 @@ class PreTrainedModelWrapper(nn.Module):
         # if resume_training, load the state_dict again - this is ok since the
         # state_dict is removed from the model after loading it.
         if isinstance(pretrained_model_name_or_path, str):
-            # TODO: Deal with sharded case!
             filename = os.path.join(pretrained_model_name_or_path, "pytorch_model.bin")
+            sharded_index_filename = os.path.join(pretrained_model_name_or_path, "pytorch_model.bin.index.json")
             is_shared = False
 
             if not os.path.exists(filename):
@@ -103,7 +103,12 @@ class PreTrainedModelWrapper(nn.Module):
                     filename = hf_hub_download(pretrained_model_name_or_path, "pytorch_model.bin")
                 # sharded
                 except:  # noqa
-                    index_file_name = hf_hub_download(pretrained_model_name_or_path, "pytorch_model.bin.index.json")
+                    if os.path.exists(sharded_index_filename):
+                        index_file_name = sharded_index_filename
+                    else:
+                        index_file_name = hf_hub_download(
+                            pretrained_model_name_or_path, "pytorch_model.bin.index.json"
+                        )
                     # load json
                     with open(index_file_name, "r") as f:
                         index = json.load(f)

--- a/trl/models/modeling_value_head.py
+++ b/trl/models/modeling_value_head.py
@@ -142,6 +142,11 @@ class AutoModelForCausalLMWithValueHead(PreTrainedModelWrapper):
             pretrained_model_state_dict[f"v_head.{k}"] = v
         return pretrained_model_state_dict
 
+    def push_to_hub(self, *args, **kwargs):
+        setattr(self.pretrained_model, "v_head", self.v_head)
+
+        return self.pretrained_model.push_to_hub(*args, **kwargs)
+
     def post_init(self, state_dict):
         r"""
         We add the state dictionary of the value head to the state dictionary of the wrapped model


### PR DESCRIPTION
# What does this PR do?

This PR addresses saving `v_head` weights when calling `save_pretrained`. Before this PR if a user wanted to share intermediate-trained `v_head` weights it was not possible. The workaround that I have found needs to load the state dict twice, once by the `from_pretrained` method that is called by the `pretrained_model` attribute and once afterwards to manually load the `v_head`.
This PR introduces a new kwarg on the method `from_pretrained` termed as `resume_training` as I think this is quite an edge case.

Added also some tests

TODOs:
- test `push_to_hub`

cc @lvwerra @lewtun 