### PR TITLE
Model as kwarg in pipeline

### DIFF
--- a/examples/scripts/ppo-sentiment-adam-8bit.py
+++ b/examples/scripts/ppo-sentiment-adam-8bit.py
@@ -115,7 +115,7 @@ ppo_trainer = PPOTrainer(config, model, ref_model, tokenizer, dataset=dataset, d
 device = ppo_trainer.accelerator.device
 if ppo_trainer.accelerator.num_processes == 1:
    device = 0 if torch.cuda.is_available() else "cpu" # to avoid a `pipeline` bug
-sentiment_pipe = pipeline("sentiment-analysis", "lvwerra/distilbert-imdb", device=device)
+sentiment_pipe = pipeline("sentiment-analysis", model="lvwerra/distilbert-imdb", device=device)
 
 # We then define the arguments to pass to the `generate` function. These arguments
 # are passed to the `generate` function of the PPOTrainer, which is a wrapper around 

--- a/examples/scripts/ppo-sentiment.py
+++ b/examples/scripts/ppo-sentiment.py
@@ -112,7 +112,7 @@ ppo_trainer = PPOTrainer(config, model, ref_model, tokenizer, dataset=dataset, d
 device = ppo_trainer.accelerator.device
 if ppo_trainer.accelerator.num_processes == 1:
    device = 0 if torch.cuda.is_available() else "cpu" # to avoid a `pipeline` bug
-sentiment_pipe = pipeline("sentiment-analysis", "lvwerra/distilbert-imdb", device=device)
+sentiment_pipe = pipeline("sentiment-analysis", model="lvwerra/distilbert-imdb", device=device)
 
 # We then define the arguments to pass to the `generate` function. These arguments
 # are passed to the `generate` function of the PPOTrainer, which is a wrapper around 


### PR DESCRIPTION
Specify the `kwarg` for the `model` parameter. I was a bit weirded out by the two-parameter pipeline until I understood it came from `transformers` and you were specifying the model/tokenizer.

Very much a nitpick, feel free to disregard if you disagree!