### PR TITLE
Fix docs hyperlinks

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -14,5 +14,6 @@ jobs:
       commit_sha: ${{ github.sha }}
       package: trl
       repo_owner: lvwerra
+      version_tag_suffix: ""
     secrets:
       token: ${{ secrets.HUGGINGFACE_PUSH }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,3 +15,4 @@ jobs:
       pr_number: ${{ github.event.number }}
       package: trl
       repo_owner: lvwerra
+      version_tag_suffix: ""


### PR DESCRIPTION
Fixes an issue with cross-references in the docs because the repo root is `trl` instead of `src`. Internal Slack thread: https://huggingface.slack.com/archives/C04EX6W3QSY/p1674470759142759