### PR TITLE
[`bug`] support for large `forward_batch_size` in seq2seq models

### DIFF
--- a/examples/scripts/ppo-sentiment-t5-small.py
+++ b/examples/scripts/ppo-sentiment-t5-small.py
@@ -45,7 +45,7 @@ config = PPOConfig(
     model_name="lvwerra/t5-imdb",
     learning_rate=5e-5,
     batch_size=256,
-    forward_batch_size=1
+    forward_batch_size=16,
 )
 # We then define the arguments to pass to the sentiment analysis pipeline.
 # We set `return_all_scores` to True to get the sentiment score for each token.

--- a/trl/models/modeling_value_head.py
+++ b/trl/models/modeling_value_head.py
@@ -307,7 +307,7 @@ class AutoModelForSeq2SeqLMWithValueHead(PreTrainedModelWrapper):
         **kwargs,
     ):
         if attention_mask is None:
-            attention_mask = input_ids.ne(self.pretrained_model.config.pad_token_id)
+            attention_mask = input_ids.ne(self.pretrained_model.config.pad_token_id).float()
 
         base_model_output = self.pretrained_model(
             input_ids=input_ids,

--- a/trl/models/modeling_value_head.py
+++ b/trl/models/modeling_value_head.py
@@ -306,6 +306,9 @@ class AutoModelForSeq2SeqLMWithValueHead(PreTrainedModelWrapper):
         attention_mask=None,
         **kwargs,
     ):
+        if attention_mask is None:
+            attention_mask = input_ids.ne(self.pretrained_model.config.pad_token_id)
+
         base_model_output = self.pretrained_model(
             input_ids=input_ids,
             past_key_values=past_key_values,

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -530,11 +530,12 @@ class PPOTrainer(BaseTrainer):
         else:
             input_ids = input_kwargs["input_ids"]
 
-        mask = (input_ids != self.tokenizer.pad_token_id).float()
+        if hasattr(self.tokenizer, "pad_token_id"):
+            mask = (input_ids != self.tokenizer.pad_token_id).float()
 
-        logits = logits * mask.unsqueeze(-1)
-        ref_logits = ref_logits * mask.unsqueeze(-1)
-        values = values * mask
+            logits = logits * mask.unsqueeze(-1)
+            ref_logits = ref_logits * mask.unsqueeze(-1)
+            values = values * mask
 
         return logits, ref_logits, values
 

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -530,7 +530,7 @@ class PPOTrainer(BaseTrainer):
         else:
             input_ids = input_kwargs["input_ids"]
 
-        if hasattr(self.tokenizer, "pad_token_id"):
+        if hasattr(self.tokenizer, "pad_token_id") and self.tokenizer.pad_token_id is not None:
             mask = (input_ids != self.tokenizer.pad_token_id).float()
 
             logits = logits * mask.unsqueeze(-1)
@@ -646,7 +646,10 @@ class PPOTrainer(BaseTrainer):
             input_kwargs["decoder_input_ids"] = response
             model_input = response
 
-        attention_mask = model_input.ne(self.tokenizer.pad_token_id)
+        if hasattr(self.tokenizer, "pad_token_id") and self.tokenizer.pad_token_id is not None:
+            attention_mask = model_input.ne(self.tokenizer.pad_token_id)
+        else:
+            attention_mask = torch.ones_like(model_input)
 
         logits, _, vpred = self.model(**input_kwargs)
 


### PR DESCRIPTION
# What does this PR do?

First of all, please welcome the PR number 100! 

Before this PR, it was not possible to run the T5 example with `forward_batch_size > 1`. We suspected that something was wrong with the computation of the loss function when padding tokens are present.

This PR fixes a bug we had for seq2seq models (and I believe for causalLM models too). It seems that we forgot to mask out the logits/hidden states that correspond to the pad tokens when computing the loss function. 

See a similar implementation here: https://github.com/CarperAI/trlx/blob/main/trlx/trainer/nn/ppo_models.py#L166-L191 where the loss takes care of ignoring the terms corresponding to pad tokens

Can also add tests! 

GPT2 run: https://wandb.ai/distill-bloom/trl/runs/4cs5z6j3?workspace=user-younesbelkada
T5 run: https://wandb.ai/distill-bloom/trl/runs/lxgi5ae9?workspace=user-younesbelkada 
It seems that now the `reward_std` is higher, leading to less smooth `reward_mean` curves, so putting this PR as draft

cc @lvwerra 