### PR TITLE
Fix Sentiment control notebook

### DIFF
--- a/examples/sentiment/notebooks/gpt2-sentiment-control.ipynb
+++ b/examples/sentiment/notebooks/gpt2-sentiment-control.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -195,7 +195,7 @@
        "})"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -261,7 +261,7 @@
        "tensor([ 770, 2646,  373, 2192, 7867])"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -296,8 +296,7 @@
     {
      "data": {
       "text/html": [
-       "wandb version 0.13.9 is available!  To upgrade, please run:\n",
-       " $ pip install wandb --upgrade"
+       "Tracking run with wandb version 0.13.9"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -309,7 +308,7 @@
     {
      "data": {
       "text/html": [
-       "Tracking run with wandb version 0.13.7"
+       "Run data is saved locally in <code>/home/leandro_huggingface_co/trl/examples/sentiment/notebooks/wandb/run-20230206_125743-jpcnr7jx</code>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -321,7 +320,7 @@
     {
      "data": {
       "text/html": [
-       "Run data is saved locally in <code>/home/leandro_huggingface_co/trl/examples/sentiment/notebooks/wandb/run-20230131_102246-1zxw8s25</code>"
+       "Syncing run <strong><a href=\"https://wandb.ai/lvwerra/trl/runs/jpcnr7jx\" target=\"_blank\">comic-music-184</a></strong> to <a href=\"https://wandb.ai/lvwerra/trl\" target=\"_blank\">Weights & Biases</a> (<a href=\"https://wandb.me/run\" target=\"_blank\">docs</a>)<br/>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -333,7 +332,19 @@
     {
      "data": {
       "text/html": [
-       "Syncing run <strong><a href=\"https://wandb.ai/lvwerra/trl/runs/1zxw8s25\" target=\"_blank\">dancing-dog-165</a></strong> to <a href=\"https://wandb.ai/lvwerra/trl\" target=\"_blank\">Weights & Biases</a> (<a href=\"https://wandb.me/run\" target=\"_blank\">docs</a>)<br/>"
+       " View project at <a href=\"https://wandb.ai/lvwerra/trl\" target=\"_blank\">https://wandb.ai/lvwerra/trl</a>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       " View run at <a href=\"https://wandb.ai/lvwerra/trl/runs/jpcnr7jx\" target=\"_blank\">https://wandb.ai/lvwerra/trl/runs/jpcnr7jx</a>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -357,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -387,7 +398,7 @@
        " {'label': 'POSITIVE', 'score': -2.726576328277588}]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -400,7 +411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -410,7 +421,7 @@
        " {'label': 'NEGATIVE', 'score': -2.294790267944336}]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -423,7 +434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -433,7 +444,7 @@
        " {'label': 'NEGATIVE', 'score': -0.7086048126220703}]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -453,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -468,7 +479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -477,7 +488,7 @@
        "-0.7086048126220703"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -496,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -507,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -518,7 +529,7 @@
        " '[positive]': tensor([   58, 24561,    60], device='cuda:0')}"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -536,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -568,7 +579,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -585,7 +596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -594,7 +605,7 @@
        "tensor([-4., -4.,  4.])"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -605,7 +616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -614,7 +625,7 @@
        "tensor([ 4., -4., -4.])"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -625,7 +636,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -634,7 +645,7 @@
        "tensor([-0., 4., 0.])"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -652,7 +663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -662,7 +673,8 @@
     "    \"top_p\": 1.0,\n",
     "    \"do_sample\": True,\n",
     "    \"pad_token_id\": gpt2_tokenizer.eos_token_id,\n",
-    "    \"max_new_tokens\": txt_out_len\n",
+    "    \"max_new_tokens\": txt_out_len,\n",
+    "    \"eos_token_id\": -1\n",
     "}\n"
    ]
   },
@@ -698,18 +710,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  9%|▉         | 7/80 [14:00<2:26:12, 120.17s/it]/home/leandro_huggingface_co/miniconda3/envs/trl/lib/python3.9/site-packages/transformers/pipelines/base.py:1043: UserWarning: You seem to be using the pipelines sequentially on GPU. In order to maximize efficiency please use a dataset\n",
+      "  8%|▊         | 6/80 [12:44<2:37:54, 128.03s/it]/home/leandro_huggingface_co/miniconda3/envs/trl/lib/python3.9/site-packages/transformers/pipelines/base.py:1045: UserWarning: You seem to be using the pipelines sequentially on GPU. In order to maximize efficiency please use a dataset\n",
       "  warnings.warn(\n",
-      " 42%|████▎     | 34/80 [1:08:25<1:32:49, 121.08s/it]\u001b[34m\u001b[1mwandb\u001b[0m: \u001b[33mWARNING\u001b[0m A graphql request initiated by the public wandb API timed out (timeout=9 sec). Create a new API with an integer timeout larger than 9, e.g., `api = wandb.Api(timeout=19)` to increase the graphql timeout.\n",
-      "\u001b[34m\u001b[1mwandb\u001b[0m: \u001b[33mWARNING\u001b[0m A graphql request initiated by the public wandb API timed out (timeout=9 sec). Create a new API with an integer timeout larger than 9, e.g., `api = wandb.Api(timeout=19)` to increase the graphql timeout.\n",
-      " 54%|█████▍    | 43/80 [1:27:05<1:15:11, 121.94s/it]"
+      "100%|██████████| 80/80 [2:46:39<00:00, 124.99s/it]  \n",
+      " 91%|█████████▏| 73/80 [2:30:39<14:35, 125.03s/it]  "
      ]
     }
    ],
@@ -741,7 +752,7 @@
     "\n",
     "        for cs in ctrl_str:\n",
     "            key = 'env/reward_'+cs.strip('[]')\n",
-    "            stats[key] = np.mean([r for r, t in zip(stats['env/reward_dist'], task_list) if t==cs])\n",
+    "            stats[key] = np.mean([r.cpu().numpy() for r, t in zip(rewards, task_list) if t==cs])\n",
     "        ppo_trainer.log_stats(stats, game_data, rewards)\n"
    ]
   },
@@ -840,7 +851,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.16"
   },
   "vscode": {
    "interpreter": {

--- a/examples/sentiment/notebooks/gpt2-sentiment-control.ipynb
+++ b/examples/sentiment/notebooks/gpt2-sentiment-control.ipynb
@@ -738,7 +738,11 @@
     "        #### Run PPO training \n",
     "        t = time.time()\n",
     "        stats = ppo_trainer.step(query_tensors, response_tensors, rewards)\n",
-    "        ppo_trainer.log_stats(stats, game_data, rewards)"
+    "\n",
+    "        for cs in ctrl_str:\n",
+    "            key = 'env/reward_'+cs.strip('[]')\n",
+    "            stats[key] = np.mean([r for r, t in zip(stats['env/reward_dist'], task_list) if t==cs])\n",
+    "        ppo_trainer.log_stats(stats, game_data, rewards)\n"
    ]
   },
   {

--- a/examples/sentiment/notebooks/gpt2-sentiment-control.ipynb
+++ b/examples/sentiment/notebooks/gpt2-sentiment-control.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -195,7 +195,7 @@
        "})"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -261,7 +261,7 @@
        "tensor([ 770, 2646,  373, 2192, 7867])"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -321,7 +321,7 @@
     {
      "data": {
       "text/html": [
-       "Run data is saved locally in <code>/home/leandro_huggingface_co/younes_trl/trl/examples/notebooks/wandb/run-20230125_104814-3s8qylnp</code>"
+       "Run data is saved locally in <code>/home/leandro_huggingface_co/trl/examples/sentiment/notebooks/wandb/run-20230131_102246-1zxw8s25</code>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -333,7 +333,7 @@
     {
      "data": {
       "text/html": [
-       "Syncing run <strong><a href=\"https://wandb.ai/lvwerra/trl/runs/3s8qylnp\" target=\"_blank\">dancing-envelope-164</a></strong> to <a href=\"https://wandb.ai/lvwerra/trl\" target=\"_blank\">Weights & Biases</a> (<a href=\"https://wandb.me/run\" target=\"_blank\">docs</a>)<br/>"
+       "Syncing run <strong><a href=\"https://wandb.ai/lvwerra/trl/runs/1zxw8s25\" target=\"_blank\">dancing-dog-165</a></strong> to <a href=\"https://wandb.ai/lvwerra/trl\" target=\"_blank\">Weights & Biases</a> (<a href=\"https://wandb.me/run\" target=\"_blank\">docs</a>)<br/>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -357,7 +357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,7 +377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -387,7 +387,7 @@
        " {'label': 'POSITIVE', 'score': -2.726576328277588}]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -400,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -410,7 +410,7 @@
        " {'label': 'NEGATIVE', 'score': -2.294790267944336}]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -423,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -433,7 +433,7 @@
        " {'label': 'NEGATIVE', 'score': -0.7086048126220703}]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -453,7 +453,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def extract_pipe_output(outputs):\n",
+    "    positive_logits = []\n",
+    "    for out in outputs:\n",
+    "        for element in out:\n",
+    "            if element[\"label\"]==\"POSITIVE\":\n",
+    "                positive_logits.append(torch.tensor(element[\"score\"]))\n",
+    "    return positive_logits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -462,7 +477,7 @@
        "-0.7086048126220703"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -481,7 +496,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -492,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -503,7 +518,7 @@
        " '[positive]': tensor([   58, 24561,    60], device='cuda:0')}"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -521,7 +536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -553,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -570,7 +585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -579,7 +594,7 @@
        "tensor([-4., -4.,  4.])"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -590,7 +605,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -599,7 +614,7 @@
        "tensor([ 4., -4., -4.])"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -610,7 +625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -619,7 +634,7 @@
        "tensor([-0., 4., 0.])"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -637,7 +652,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -683,16 +698,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  9%|▉         | 7/80 [13:18<2:19:19, 114.51s/it]/home/leandro_huggingface_co/miniconda3/envs/trl/lib/python3.9/site-packages/transformers/pipelines/base.py:1043: UserWarning: You seem to be using the pipelines sequentially on GPU. In order to maximize efficiency please use a dataset\n",
+      "  9%|▉         | 7/80 [14:00<2:26:12, 120.17s/it]/home/leandro_huggingface_co/miniconda3/envs/trl/lib/python3.9/site-packages/transformers/pipelines/base.py:1043: UserWarning: You seem to be using the pipelines sequentially on GPU. In order to maximize efficiency please use a dataset\n",
       "  warnings.warn(\n",
-      " 30%|███       | 24/80 [45:56<1:47:38, 115.33s/it]"
+      " 42%|████▎     | 34/80 [1:08:25<1:32:49, 121.08s/it]\u001b[34m\u001b[1mwandb\u001b[0m: \u001b[33mWARNING\u001b[0m A graphql request initiated by the public wandb API timed out (timeout=9 sec). Create a new API with an integer timeout larger than 9, e.g., `api = wandb.Api(timeout=19)` to increase the graphql timeout.\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: \u001b[33mWARNING\u001b[0m A graphql request initiated by the public wandb API timed out (timeout=9 sec). Create a new API with an integer timeout larger than 9, e.g., `api = wandb.Api(timeout=19)` to increase the graphql timeout.\n",
+      " 54%|█████▍    | 43/80 [1:27:05<1:15:11, 121.94s/it]"
      ]
     }
    ],
@@ -715,7 +732,7 @@
     "\n",
     "        #### sentiment analysis\n",
     "        texts = [q + r for q,r in zip(batch['query'], game_data['response'])]\n",
-    "        logits = [torch.tensor(output[1][\"score\"]) for output in sentiment_pipe(texts, **sentiment_pipe_kwargs)]\n",
+    "        logits = extract_pipe_output(sentiment_pipe(texts, **sentiment_pipe_kwargs))\n",
     "        rewards = pos_logit_to_reward(logits, task_list)\n",
     "\n",
     "        #### Run PPO training \n",
@@ -805,7 +822,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "env",
+   "display_name": "trl",
    "language": "python",
    "name": "python3"
   },
@@ -819,11 +836,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12 (main, Mar 26 2022, 15:51:15) \n[Clang 13.1.6 (clang-1316.0.21.2)]"
+   "version": "3.9.15"
   },
   "vscode": {
    "interpreter": {
-    "hash": "4c8ff454cd947027f86954d72bf940c689a97dcc494eb53cfe4813862c6065fe"
+    "hash": "d2cfb53525227c89f8d14fa784301fa46c451cc9223d94ccce9e17956835eea2"
    }
   }
  },


### PR DESCRIPTION
This is an attempt to fix the instabilities in the controlled sentiment generation.

Changes so far:
 - fix logit computation for reward (pipeline changes order natively which can cause the position of the logit to switch)
 - In generate kwargs add `"eos_token_id": -1`

The last point makes sure that the model keeps generating until the max new tokens is reached. I think what happens otherwise is that sometimes the model only generates 1-2 tokens in which case the PPO loss spikes (don't know why, yet). 

The last successful run is [here](https://wandb.ai/lvwerra/trl/runs/jpcnr7jx?workspace=user-lvwerra).