### PR TITLE
add `set_seed` to __init__.py

### DIFF
--- a/examples/sentiment/scripts/gpt2-sentiment.py
+++ b/examples/sentiment/scripts/gpt2-sentiment.py
@@ -20,8 +20,8 @@ tqdm.pandas()
 from transformers import pipeline, AutoTokenizer
 from datasets import load_dataset
 
-from trl import PPOTrainer, PPOConfig, AutoModelForCausalLMWithValueHead
-from trl.core import LengthSampler, set_seed
+from trl import PPOTrainer, PPOConfig, AutoModelForCausalLMWithValueHead, set_seed
+from trl.core import LengthSampler
 
 ########################################################################
 # This is a fully working simple example to use trl with accelerate.

--- a/examples/sentiment/scripts/t5-sentiment.py
+++ b/examples/sentiment/scripts/t5-sentiment.py
@@ -19,8 +19,8 @@ tqdm.pandas()
 from transformers import pipeline, AutoTokenizer
 from datasets import load_dataset
 
-from trl import PPOTrainer, PPOConfig, AutoModelForSeq2SeqLMWithValueHead
-from trl.core import LengthSampler, set_seed
+from trl import PPOTrainer, PPOConfig, AutoModelForSeq2SeqLMWithValueHead, set_seed
+from trl.core import LengthSampler
 
 ########################################################################
 # This is a fully working simple example to use trl with accelerate.

--- a/tests/trainer/test_ppo_trainer.py
+++ b/tests/trainer/test_ppo_trainer.py
@@ -97,7 +97,6 @@ class PPOTrainerTester(unittest.TestCase):
                 pass
 
     def setUp(self):
-
         # model_id
         model_id = "gpt2"
 

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -2,6 +2,7 @@
 
 __version__ = "0.2.2.dev0"
 
+from .core import set_seed
 from .models import (
     AutoModelForCausalLMWithValueHead,
     AutoModelForSeq2SeqLMWithValueHead,


### PR DESCRIPTION
This adds `set_seed` to the main `__init__.py` so we can `from trl import set_seed`. I think we should move important stuff the users is supposed to use there so they don't have to remember paths. Wdyt @younesbelkada? 

cc @natolambert 