### PR TITLE
[`core`] enable `bf16` training

### DIFF
--- a/trl/core.py
+++ b/trl/core.py
@@ -133,7 +133,10 @@ def stats_to_np(stats_dict):
     new_dict = dict()
     for k, v in stats_dict.items():
         if isinstance(v, torch.Tensor):
-            new_dict[k] = v.detach().cpu().numpy()
+            new_dict[k] = v.detach().cpu()
+            if new_dict[k].dtype == torch.bfloat16:
+                new_dict[k] = new_dict[k].float()
+            new_dict[k] = new_dict[k].numpy()
         else:
             new_dict[k] = v
         if np.isscalar(new_dict[k]):

--- a/trl/models/modeling_value_head.py
+++ b/trl/models/modeling_value_head.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import torch
 import torch.nn as nn
 from transformers import AutoModelForCausalLM, AutoModelForSeq2SeqLM
 
@@ -170,6 +170,10 @@ class AutoModelForCausalLMWithValueHead(PreTrainedModelWrapper):
 
         value = self.v_head(last_hidden_state).squeeze(-1)
 
+        # force upcast in fp32 if logits are in half-precision
+        if lm_logits.dtype != torch.float32:
+            lm_logits = lm_logits.float()
+
         return (lm_logits, loss, value)
 
     def generate(self, *args, **kwargs):
@@ -319,6 +323,10 @@ class AutoModelForSeq2SeqLMWithValueHead(PreTrainedModelWrapper):
         loss = base_model_output.loss
 
         value = self.v_head(last_hidden_state).squeeze(-1)
+
+        # force upcast in fp32 if logits are in half-precision
+        if lm_logits.dtype != torch.float32:
+            lm_logits = lm_logits.float()
 
         return (lm_logits, loss, value)
 

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -263,12 +263,6 @@ class PPOTrainer(BaseTrainer):
         # init the current step
         self.current_step = 0
 
-        # init wandb on the main process:
-        if self.accelerator.is_main_process and self.config.log_with == "wandb":
-            import wandb
-
-            wandb.watch(self.model, log="all")
-
         if self.config.forward_batch_size > 1 and (self.is_encoder_decoder or self.tokenizer.padding_side == "left"):
             # warn users that this is not well supported yet
             logging.warning(

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -864,6 +864,12 @@ class PPOTrainer(BaseTrainer):
                 rewards /= self.accelerator.num_processes
 
             logs.update(stats)
+
+            # manually cast in fp32 for bf16 torch tensors
+            for k, v in logs.items():
+                if isinstance(v, torch.Tensor) and v.dtype == torch.bfloat16:
+                    logs[k] = v.float()
+
             logs["env/reward_mean"] = torch.mean(rewards).cpu().numpy().item()
             logs["env/reward_std"] = torch.std(rewards).cpu().numpy().item()
             logs["env/reward_dist"] = rewards.cpu().numpy()


### PR DESCRIPTION
Currently on the `main` branch of `trl` training in `bfloat16` & logging with `wandb` fails. Users will encounter an error that are hard to interpret.

The fixes are the following:

- remove `wandb.watch(model)` as it takes care of logging gradients that are in bf16, otherwise users will get an error that is similar to https://github.com/wandb/wandb/issues/3332 | I propose to remove this is not a core feature and is a main blocking point
- upcast the tensors in fp32 before logging them
- force-upcast the `lm_logits` in fp32 

cc @lvwerra 