### PR TITLE
[`core`] fix saving multi-gpu

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -906,6 +906,7 @@ class PPOTrainer(BaseTrainer):
             f.write(model_card_content)
 
     def _save_pretrained(self, save_directory: str) -> None:
+        self.accelerator.unwrap_model(self.model).save_pretrained(save_directory)
         self.model.save_pretrained(save_directory)
         self.tokenizer.save_pretrained(save_directory)
         self.create_model_card(save_directory)

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -907,6 +907,5 @@ class PPOTrainer(BaseTrainer):
 
     def _save_pretrained(self, save_directory: str) -> None:
         self.accelerator.unwrap_model(self.model).save_pretrained(save_directory)
-        self.model.save_pretrained(save_directory)
         self.tokenizer.save_pretrained(save_directory)
         self.create_model_card(save_directory)


### PR DESCRIPTION
Currently on the `main` branch of `trl` saving a `PPOTrainer` in a multi-GPU setting is broken. The fix is to first call `self.accelerator.unwrap_model(self.model)` before calling `save_pretrained`

cc @lvwerra  