### PR TITLE
[`core`] Add `max_grad_norm` support

### DIFF
--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -645,7 +645,7 @@ class PPOTrainerTester(unittest.TestCase):
 
     def test_ppo_trainer_max_grad_norm(self):
         """
-        Test if the loss trainer works fine
+        Test if the `max_grad_norm` feature works as expected
         """
         # initialize dataset
         dummy_dataset = self._init_dummy_dataset()

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -643,6 +643,41 @@ class PPOTrainerTester(unittest.TestCase):
         self.assertLessEqual(abs_diff_masked_tensors(logprobs_0, logprobs_2[:1], mask_0, mask_2[:1]), 1e-4)
         self.assertLessEqual(abs_diff_masked_tensors(values_0, values_2[:1], mask_0, mask_2[:1]), 1e-4)
 
+    def test_ppo_trainer_max_grad_norm(self):
+        """
+        Test if the loss trainer works fine
+        """
+        # initialize dataset
+        dummy_dataset = self._init_dummy_dataset()
+
+        self.ppo_config.max_grad_norm = 0.00001
+        ppo_trainer = PPOTrainer(
+            config=self.ppo_config,
+            model=self.gpt2_model,
+            ref_model=None,
+            tokenizer=self.gpt2_tokenizer,
+            dataset=dummy_dataset,
+        )
+
+        dummy_dataloader = ppo_trainer.dataloader
+
+        # train model with ppo
+        for query_tensor, response_tensor in dummy_dataloader:
+            # define a reward for response
+            # (this could be any reward such as human feedback or output from another model)
+            reward = [torch.tensor(1.0), torch.tensor(0.0)]
+            # train model
+            _ = ppo_trainer.step([q for q in query_tensor], [r for r in response_tensor], reward)
+            break
+
+        # check gradients
+        for name, param in ppo_trainer.model.named_parameters():
+            self.assertTrue(param.grad is not None, f"Parameter {name} has no gradient")
+            self.assertTrue(
+                torch.all(param.grad.abs() <= self.ppo_config.max_grad_norm),
+                f"Parameter {name} has a gradient larger than max_grad_norm",
+            )
+
     @unittest.skip("Fix by either patching `whomai()` to work in the staging endpoint or use a dummy prod user.")
     def test_push_to_hub(self):
         REPO_NAME = "test-ppo-trainer"

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -69,6 +69,8 @@ class PPOConfig(object):
             Keyword arguments for the tracker (e.g. wandb_project)
         tracker_project_name (`str`, *optional*, defaults to "trl"):
             Name of project to use for tracking
+        max_grad_norm (`float`, *optional*, defaults to `None`):
+            Maximum gradient norm for gradient clipping
         seed (`int`, *optional*, defaults to 0):
             Seed value for random generations
     """
@@ -96,6 +98,7 @@ class PPOConfig(object):
         tracker_kwargs: Optional[dict] = {},
         accelerator_kwargs: Optional[dict] = {},
         tracker_project_name: Optional[str] = "trl",
+        max_grad_norm: Optional[float] = None,
         seed: Optional[int] = 0,
     ):
         self.model_name = model_name
@@ -136,6 +139,7 @@ class PPOConfig(object):
         self.tracker_kwargs = tracker_kwargs
         self.accelerator_kwargs = accelerator_kwargs
         self.tracker_project_name = tracker_project_name
+        self.max_grad_norm = max_grad_norm
 
         self.total_ppo_epochs = int(np.ceil(steps / batch_size))
 

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -682,6 +682,12 @@ class PPOTrainer(BaseTrainer):
         loss = loss_p + loss_v
         self.optimizer.zero_grad()
         self.accelerator.backward(loss)
+
+        if self.config.max_grad_norm is not None:
+            torch.nn.utils.clip_grad_norm_(
+                filter(lambda p: p.requires_grad, self.model.parameters()), self.config.max_grad_norm
+            )
+
         t = time.time()
         self.optimizer.step()
         train_stats["time/ppo/optimizer_step"] = torch.Tensor([time.time() - t]).to(self.accelerator.device)


### PR DESCRIPTION
# What does this PR do?

This PR adds the support of clipping gradients norm, that was not supported before but implemented in other frameworks such as clean RL: https://github.com/vwxyzjn/cleanrl/blob/2e41da2a3649c50f27121d74896110fe8f69dd52/cleanrl/ppo.py#L286 

This PR also adds a nice test

I can confirm multi-GPU training works with this PR (ran 1 PPO step of `gpt2-sentiment` with 2 GPU)

cc @edbeeching @lvwerra @natolambert 