### PR TITLE
Let's support naive Pipeline Parallelism

### DIFF
--- a/docs/source/customization.mdx
+++ b/docs/source/customization.mdx
@@ -142,3 +142,11 @@ ppo_config = {'batch_size': 1}
 config = PPOConfig(**ppo_config)
 ppo_trainer = PPOTrainer(config, model, model_ref, tokenizer)
 ```
+
+## Use the CUDA cache optimizer
+
+When training large models, you should better handle the CUDA cache by iteratively clearing it. Do do so, simply pass `optimize_cuda_cache=True` to `PPOConfig`:
+
+```python
+config = PPOConfig(..., optimize_cuda_cache=True)
+```

--- a/docs/source/sentiment_tuning_peft.mdx
+++ b/docs/source/sentiment_tuning_peft.mdx
@@ -9,7 +9,8 @@ Here's an overview of the notebooks and scripts in the [trl repository](https://
 | [`gpt2-sentiment_peft.py`](https://github.com/lvwerra/trl/blob/main/examples/sentiment/scripts/gpt2-sentiment_peft.py) | Same as the sentiment analysis example, but learning a low rank adapter on a 8-bit base model |  | 
 | [`cm_finetune_peft_imdb.py`](https://github.com/lvwerra/trl/blob/main/examples/sentiment/scripts/gpt-neox-20b_peft/cm_finetune_peft_imdb.py) | Fine tuning a Low Rank Adapter on a frozen 8-bit model for text generation on the imdb dataset. |  | 
 | [`merge_peft_adapter.py`](https://github.com/lvwerra/trl/blob/main/examples/sentiment/scripts/gpt-neox-20b_peft/merge_peft_adapter.py) |  Merging of the adapter layers into the base model’s weights and storing these on the hub. |  | 
-| [`gpt-neo-20b_sentiment_peft.py`](https://github.com/lvwerra/trl/blob/main/examples/sentiment/scripts/gpt-neox-20b_peft/gpt-neo-20b_sentiment_peft.py.py) | Sentiment fine-tuning of a Low Rank Adapter to create positive reviews. |  | 
+| [`gpt-neo-20b_sentiment_peft.py`](https://github.com/lvwerra/trl/blob/main/examples/sentiment/scripts/gpt-neox-20b_peft/gpt-neo-20b_sentiment_peft.py) | Sentiment fine-tuning of a Low Rank Adapter to create positive reviews. |  | 
+| [`gpt-neo-1b_peft.py`](https://github.com/lvwerra/trl/blob/main/examples/sentiment/scripts/gpt-neo-1b-multi-gpu/gpt-neo-1b_peft.py) | Sentiment fine-tuning of a Low Rank Adapter to create positive reviews using 2 GPUs. |  | 
 
 ## Installation
 Note: peft is in active development, so we install directly from their github page.
@@ -33,4 +34,29 @@ The `trl` library is powered by `accelerate`. As such it is best to configure an
 ```bash
 accelerate config # will prompt you to define the training configuration
 accelerate launch scripts/gpt2-sentiment_peft.py # launches training
+```
+
+## Naive pipeline parallelism (NPP) for large models (>60B models)
+
+The `trl` library also supports naive pipeline parallelism (NPP) for large models (>60B models). This is a simple way to parallelize the model across multiple GPUs. 
+This paradigm, termed as "Naive Pipeline Parallelism" (NPP) is a simple way to parallelize the model across multiple GPUs. We load the model and the adapters across multiple GPUs and the activations and gradients will be naively communicated across the GPUs. This supports `int8` models as well as other `dtype` models.
+
+<div style="text-align: center">
+<img src="https://huggingface.co/datasets/trl-internal-testing/example-images/resolve/main/images/trl-npp.png">
+</div>
+
+### How to use NPP?
+
+Simply load your model with a custom `device_map` argument on the `from_pretrained` to split your model across multiple devices. Check out this [nice tutorial](https://github.com/huggingface/blog/blob/main/accelerate-large-models.md) on how to properly create a `device_map` for your model. 
+ 
+Also make sure to have the `lm_head` module on the first GPU device as it may throw an error if it is not on the first device. As this time of writing, you need to install the `main` branch of `accelerate`: `pip install git+https://github.com/huggingface/accelerate.git@main` and `peft`: `pip install git+https://github.com/huggingface/peft.git@main`.
+
+That all you need to do to use NPP. Check out the [gpt-neo-1b_peft.py](https://github.com/lvwerra/trl/blob/main/examples/sentiment/scripts/gpt-neo-1b-multi-gpu/gpt-neo-1b_peft.py) example for a more details usage of NPP.
+
+### Launch scripts
+
+Although `trl` library is powered by `accelerate`, you should run your training script in a single process. Note that we do not support Data Parallelism together with NPP yet.
+
+```bash
+python PATH_TO_SCRIPT
 ```

--- a/examples/sentiment/scripts/gpt-neo-1b-multi-gpu/gpt-neo-1b_peft.py
+++ b/examples/sentiment/scripts/gpt-neo-1b-multi-gpu/gpt-neo-1b_peft.py
@@ -1,0 +1,240 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass, field
+from typing import Optional
+
+import torch
+from datasets import load_dataset
+from peft import LoraConfig, get_peft_model, prepare_model_for_int8_training
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoTokenizer, HfArgumentParser, pipeline
+
+from trl import AutoModelForCausalLMWithValueHead, PPOConfig, PPOTrainer, set_seed
+from trl.core import LengthSampler
+
+
+########################################################################
+# This is a fully working simple example to use trl with accelerate.
+#
+# This example fine-tunes a GPT2 model on the IMDB dataset using PPO
+# (proximal policy optimization).
+# in any of the following settings (with the same script):
+#   - single CPU or single GPU
+#   - fp16 (mixed-precision) or fp32 (normal precision)
+#
+# To run it in each of these various modes, first initialize the accelerate
+# configuration with `accelerate config`
+#
+########################################################################
+
+########################################################################
+# NOTE for to train with a 8-bit model a more recent version of
+# transformers is required, full dependecies for this example:
+# pip install  bitsandbytes datasets accelerate loralib
+# pip install  git+https://github.com/huggingface/transformers.git@main
+# pip install peft
+########################################################################
+
+# We first define the configuration of the experiment, defining the model, the dataset,
+# the training parameters, and the PPO parameters.
+# Check the default arguments in the `PPOConfig` class for more details.
+# If you want to log with tensorboard, add the kwarg
+# `accelerator_kwargs={"logging_dir": PATH_TO_LOGS}` to the PPOConfig.
+
+
+# Define and parse arguments.
+@dataclass
+class ScriptArguments:
+    """
+    The name of the Casual LM model we wish to fine with PPO
+    """
+
+    # NOTE: gpt2 models use Conv1D instead of Linear layers which are not yet supported in 8 bit mode
+    # models like gpt-neo* models are more suitable
+    model_name: Optional[str] = field(default="EleutherAI/gpt-neox-20b", metadata={"help": "the model name"})
+    log_with: Optional[str] = field(default=None, metadata={"help": "use 'wandb' to log with wandb"})
+    learning_rate: Optional[float] = field(default=1.41e-5, metadata={"help": "the learning rate"})
+    merge_model_adapter: Optional[bool] = field(default=False, metadata={"help": "the learning rate"})
+
+
+parser = HfArgumentParser(ScriptArguments)
+script_args = parser.parse_args_into_dataclasses()[0]
+
+config = PPOConfig(
+    model_name=script_args.model_name,
+    learning_rate=script_args.learning_rate,
+    log_with=script_args.log_with,
+    batch_size=64,
+    mini_batch_size=4,
+    optimize_cuda_cache=True,
+)
+
+# We then define the arguments to pass to the sentiment analysis pipeline.
+# We set `return_all_scores` to True to get the sentiment score for each token.
+sent_kwargs = {"return_all_scores": True, "function_to_apply": "none", "batch_size": config.mini_batch_size}
+
+
+# Below is an example function to build the dataset. In our case, we use the IMDB dataset
+# from the `datasets` library. One should customize this function to train the model on
+# its own dataset.
+def build_dataset(config, dataset_name="imdb", input_min_text_length=2, input_max_text_length=8):
+    """
+    Build dataset for training. This builds the dataset from `load_dataset`, one should
+    customize this function to train the model on its own dataset.
+
+    Args:
+        dataset_name (`str`):
+            The name of the dataset to be loaded.
+
+    Returns:
+        dataloader (`torch.utils.data.DataLoader`):
+            The dataloader for the dataset.
+    """
+    tokenizer = AutoTokenizer.from_pretrained(config.model_name)
+    tokenizer.pad_token = tokenizer.eos_token
+    # load imdb with datasets
+    ds = load_dataset(dataset_name, split="train")
+    ds = ds.rename_columns({"text": "review"})
+    ds = ds.filter(lambda x: len(x["review"]) > 200, batched=False)
+
+    input_size = LengthSampler(input_min_text_length, input_max_text_length)
+
+    def tokenize(sample):
+        sample["input_ids"] = tokenizer.encode(sample["review"])[: input_size()]
+        sample["query"] = tokenizer.decode(sample["input_ids"])
+        return sample
+
+    ds = ds.map(tokenize, batched=False)
+    ds.set_format(type="torch")
+    return ds
+
+
+# We retrieve the dataloader by calling the `build_dataset` function.
+dataset = build_dataset(config)
+
+
+def collator(data):
+    return dict((key, [d[key] for d in data]) for key in data[0])
+
+
+# set seed before initializing value head for deterministic eval
+set_seed(config.seed)
+
+# Now let's build the model, the reference model, and the tokenizer.
+pretrained_model = AutoModelForCausalLM.from_pretrained(
+    config.model_name, load_in_8bit=True, device_map="balanced", max_memory={0: "800MB", 1: "800MB"}
+)
+tokenizer = AutoTokenizer.from_pretrained(config.model_name)
+
+"""### Apply LoRA
+Here comes the magic with `peft`! Let's load a `PeftModel` and specify that we are going to use low-rank adapters (LoRA) using `get_peft_model` utility function from `peft`.
+"""
+
+
+def print_trainable_parameters(model):
+    """
+    Prints the number of trainable parameters in the model.
+    """
+    trainable_params = 0
+    all_param = 0
+    for _, param in model.named_parameters():
+        all_param += param.numel()
+        if param.requires_grad:
+            trainable_params += param.numel()
+    print(
+        f"trainable params: {trainable_params} || all params: {all_param} || trainable%: {100 * trainable_params / all_param}"
+    )
+
+
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    lora_dropout=0.05,
+    bias="none",
+    task_type="CAUSAL_LM",
+)
+
+pretrained_model = prepare_model_for_int8_training(pretrained_model)
+pretrained_model = get_peft_model(pretrained_model, lora_config)
+
+model = AutoModelForCausalLMWithValueHead.from_pretrained(pretrained_model)
+
+model.gradient_checkpointing_disable = model.pretrained_model.gradient_checkpointing_disable
+model.gradient_checkpointing_enable = model.pretrained_model.gradient_checkpointing_enable
+
+print_trainable_parameters(model)
+
+# GPT-2 tokenizer has a pad token, but it is not eos_token by default. We need to set it to eos_token.
+# only for this model.
+tokenizer.pad_token = tokenizer.eos_token
+
+optimizer = torch.optim.Adam(filter(lambda p: p.requires_grad, model.parameters()), lr=config.learning_rate)
+# We then build the PPOTrainer, passing the model, the reference model, the tokenizer
+ppo_trainer = PPOTrainer(
+    config, model, ref_model=None, tokenizer=tokenizer, dataset=dataset, data_collator=collator, optimizer=optimizer
+)
+
+# We then build the sentiment analysis pipeline, passing the model name and the
+# sentiment analysis pipeline arguments. Let's also make sure to set the device
+# to the same device as the PPOTrainer.
+device = ppo_trainer.accelerator.device
+if ppo_trainer.accelerator.num_processes == 1:
+    device = 0 if torch.cuda.is_available() else "cpu"  # to avoid a `pipeline` bug
+sentiment_pipe = pipeline("sentiment-analysis", model="lvwerra/distilbert-imdb", device=device)
+
+# We then define the arguments to pass to the `generate` function. These arguments
+# are passed to the `generate` function of the PPOTrainer, which is a wrapper around
+# the `generate` function of the trained model.
+generation_kwargs = {
+    "min_length": -1,
+    "top_k": 0.0,
+    "top_p": 1.0,
+    "do_sample": True,
+    "pad_token_id": tokenizer.eos_token_id,
+    "eos_token_id": -1,
+}
+output_min_length = 4
+output_max_length = 16
+output_length_sampler = LengthSampler(output_min_length, output_max_length)
+
+
+for epoch, batch in tqdm(enumerate(ppo_trainer.dataloader)):
+    query_tensors = batch["input_ids"]
+
+    model.gradient_checkpointing_disable()
+    model.pretrained_model.config.use_cache = True
+    # Get response from Causal LM
+    response_tensors = []
+    for query in query_tensors:
+        gen_len = output_length_sampler()
+        generation_kwargs["max_new_tokens"] = gen_len
+        response = ppo_trainer.generate(query, **generation_kwargs)
+        response_tensors.append(response.squeeze()[-gen_len:])
+    batch["response"] = [tokenizer.decode(r.squeeze()) for r in response_tensors]
+
+    # Compute sentiment score
+    texts = [q + r for q, r in zip(batch["query"], batch["response"])]
+    pipe_outputs = sentiment_pipe(texts, **sent_kwargs)
+    rewards = [torch.tensor(output[1]["score"]) for output in pipe_outputs]
+
+    # Run PPO step
+    model.gradient_checkpointing_enable()
+    model.pretrained_model.config.use_cache = False
+
+    stats = ppo_trainer.step(query_tensors, response_tensors, rewards)
+    ppo_trainer.log_stats(stats, batch, rewards)
+
+
+model.push_to_hub(f"{script_args.model_name}-ppo-sentiment")

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -29,7 +29,7 @@ from trl import AutoModelForCausalLMWithValueHead, AutoModelForSeq2SeqLMWithValu
 from trl.core import respond_to_batch
 
 from .testing_constants import CI_HUB_ENDPOINT, CI_HUB_USER, CI_HUB_USER_TOKEN
-from .testing_utils import require_peft
+from .testing_utils import require_peft, require_torch_multi_gpu
 
 
 EXPECTED_STATS = [
@@ -778,3 +778,70 @@ class PPOTrainerTester(unittest.TestCase):
                     ],
                 )
             )
+
+    @require_peft
+    @require_torch_multi_gpu
+    @mark.peft_test
+    def test_peft_model_ppo_trainer_multi_gpu(self):
+        from peft import LoraConfig, get_peft_model
+        from transformers import AutoModelForCausalLM
+
+        lora_config = LoraConfig(
+            r=16,
+            lora_alpha=32,
+            lora_dropout=0.05,
+            bias="none",
+            task_type="CAUSAL_LM",
+        )
+        gpt2_model = AutoModelForCausalLM.from_pretrained(
+            "gpt2", device_map="balanced", max_memory={0: "500MB", 1: "500MB"}
+        )
+
+        self.assertTrue(set(gpt2_model.hf_device_map.values()) == {0, 1})
+
+        # this line is very important
+        def make_inputs_require_grad(module, input, output):
+            output.requires_grad_(True)
+
+        gpt2_model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
+
+        peft_model = get_peft_model(gpt2_model, lora_config)
+        model = AutoModelForCausalLMWithValueHead.from_pretrained(peft_model)
+
+        self.assertTrue(model.is_sequential_parallel)
+
+        dummy_dataset = self._init_dummy_dataset()
+        self.ppo_config.batch_size = 2
+        self.ppo_config.mini_batch_size = 1
+
+        ppo_trainer = PPOTrainer(
+            config=self.ppo_config,
+            model=model,
+            ref_model=None,
+            tokenizer=self.gpt2_tokenizer,
+            dataset=dummy_dataset,
+        )
+
+        self.assertTrue(ppo_trainer.ref_model is None)
+
+        dummy_dataloader = ppo_trainer.dataloader
+
+        # train model with ppo
+        for query_tensor, response_tensor in dummy_dataloader:
+            # define a reward for response
+            # (this could be any reward such as human feedback or output from another model)
+            reward = [torch.tensor(1.0), torch.tensor(0.0)]
+            # train model by running a step twice
+            _ = ppo_trainer.step([q for q in query_tensor], [r for r in response_tensor], reward)
+
+            ppo_trainer.model.train()
+            ppo_trainer.model.gradient_checkpointing_enable()
+            _ = ppo_trainer.step([q for q in query_tensor], [r for r in response_tensor], reward)
+            break
+
+        # check gradients
+        for name, param in model.named_parameters():
+            if "lora" in name or "v_head" in name:
+                self.assertTrue(param.grad is not None, f"Parameter {name} has a no gradient")
+            else:
+                self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 import unittest
 
+import torch
+
 from trl import is_peft_available
 
 
@@ -22,4 +24,13 @@ def require_peft(test_case):
     """
     if not is_peft_available():
         test_case = unittest.skip("test requires peft")(test_case)
+    return test_case
+
+
+def require_torch_multi_gpu(test_case):
+    """
+    Decorator marking a test that requires multiple GPUs. Skips the test if there aren't enough GPUs.
+    """
+    if torch.cuda.device_count() < 2:
+        test_case = unittest.skip("test requires multiple GPUs")(test_case)
     return test_case

--- a/trl/core.py
+++ b/trl/core.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import random
+from contextlib import contextmanager
 
 import numpy as np
 import torch
@@ -240,3 +242,16 @@ class LengthSampler:
 
     def __call__(self):
         return np.random.choice(self.values)
+
+
+class PPODecorators(object):
+    optimize_cuda_cache = False
+
+    @classmethod
+    @contextmanager
+    def empty_cuda_cache(cls):
+        yield
+        if cls.optimize_cuda_cache and torch.cuda.is_available():
+            gc.collect()
+            torch.cuda.empty_cache()
+            gc.collect()

--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -60,6 +60,7 @@ class PreTrainedModelWrapper(nn.Module):
         self.config = pretrained_model.config
         self.prepare_inputs_for_generation = pretrained_model.prepare_inputs_for_generation
         self.is_loaded_in_8bit = getattr(pretrained_model, "is_loaded_in_8bit", False)
+        self.is_sequential_parallel = False
 
         if hasattr(pretrained_model, "gradient_checkpointing_disable"):
             self.gradient_checkpointing_disable = pretrained_model.gradient_checkpointing_disable

--- a/trl/models/modeling_value_head.py
+++ b/trl/models/modeling_value_head.py
@@ -110,17 +110,6 @@ class AutoModelForCausalLMWithValueHead(PreTrainedModelWrapper):
 
         self._init_weights(**v_head_kwargs)
 
-    def _get_lm_head_device(self):
-        r"""
-        Returns the device of the language model head.
-        """
-        for attribute in self.lm_head_namings:
-            if hasattr(self.pretrained_model, attribute):
-                if isinstance(getattr(self.pretrained_model, attribute), nn.Sequential):
-                    return getattr(self.pretrained_model, attribute)[0].weight.device
-                else:
-                    return getattr(self.pretrained_model, attribute).weight.device
-
     def _init_weights(self, **kwargs):
         r"""
         Initializes the weights of the value head. The default initialization strategy is random.
@@ -168,9 +157,6 @@ class AutoModelForCausalLMWithValueHead(PreTrainedModelWrapper):
                 Additional keyword arguments, that are passed to the wrapped model.
         """
         kwargs["output_hidden_states"] = True  # this had already been set in the LORA / PEFT examples
-
-        # lm_head_device = self._get_lm_head_device()
-        # kwargs["labels"] = kwargs["labels"].to(lm_head_device)
 
         base_model_output = self.pretrained_model(
             input_ids=input_ids,

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -101,8 +101,8 @@ class PPOConfig(object):
         accelerator_kwargs: Optional[dict] = {},
         tracker_project_name: Optional[str] = "trl",
         max_grad_norm: Optional[float] = None,
-        optimize_cuda_cache: Optional[bool] = False,
         seed: Optional[int] = 0,
+        optimize_cuda_cache: Optional[bool] = False,
     ):
         self.model_name = model_name
         self.steps = steps

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -73,6 +73,8 @@ class PPOConfig(object):
             Maximum gradient norm for gradient clipping
         seed (`int`, *optional*, defaults to 0):
             Seed value for random generations
+        optimize_cuda_cache (`bool`, *optional*, defaults to `False`):
+            Optimize CUDA cache for slightly more memory-effcient training
     """
 
     def __init__(
@@ -99,6 +101,7 @@ class PPOConfig(object):
         accelerator_kwargs: Optional[dict] = {},
         tracker_project_name: Optional[str] = "trl",
         max_grad_norm: Optional[float] = None,
+        optimize_cuda_cache: Optional[bool] = False,
         seed: Optional[int] = 0,
     ):
         self.model_name = model_name
@@ -139,6 +142,7 @@ class PPOConfig(object):
         self.tracker_kwargs = tracker_kwargs
         self.accelerator_kwargs = accelerator_kwargs
         self.tracker_project_name = tracker_project_name
+        self.optimize_cuda_cache = optimize_cuda_cache
         self.max_grad_norm = max_grad_norm
 
         self.total_ppo_epochs = int(np.ceil(steps / batch_size))

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -270,7 +270,7 @@ class PPOTrainer(BaseTrainer):
         self.current_step = 0
 
         # post process for PP
-        if not self.model.is_sequential_parallel:
+        if not getattr(self.model, "is_sequential_parallel", False):
             self.current_device = self.accelerator.device
         else:
             self.current_device = torch.device("cuda:0")


### PR DESCRIPTION
# What does this PR do?

Trying to load a model in a single device is cool, but what if we can split the model across multiple devices? 
Users will just have to pass a custom `device_map` when loading the model, and it should work out of the box.

This PR adds the support of "Sequential Parallel" - termed as naive Pipeline Parallelism as the real Pipeline parallelism involves dealing with multi-processing and gradients synchronisation that cannot be handled easily.

This PR depends on the following PRs:

- `accelerate`: https://github.com/huggingface/accelerate/pull/1172
- `peft`: https://github.com/huggingface/peft/pull/145

TODOs:

- users should NOT apply DP and/or DeepSpeed with this approach as it remains untested
- should we introduce multi-gpu tests that we optionally run?
- test with 8bit models
- update docs

cc @lvwerra @edbeeching 