### PR TITLE
Small changes when integrating into H4

### DIFF
--- a/examples/toxicity/scripts/gpt-j-6b-toxicity.py
+++ b/examples/toxicity/scripts/gpt-j-6b-toxicity.py
@@ -134,7 +134,7 @@ tokenizer.pad_token = tokenizer.eos_token
 
 # We then build the PPOTrainer, passing the model, the reference model, the tokenizer
 ppo_trainer = PPOTrainer(
-    config, model, ref_model=ref_model, tokenizer=tokenizer, dataset=dataset, data_collator=collator
+    config, model, ref_model=ref_model, tokenizer=tokenizer, dataset=dataset, data_collator=collator, optimizer=optimizer,
 )
 
 # We then build the reward pipeline, we will use the toxicity model to compute the reward.

--- a/examples/toxicity/scripts/gpt-j-6b-toxicity.py
+++ b/examples/toxicity/scripts/gpt-j-6b-toxicity.py
@@ -134,7 +134,13 @@ tokenizer.pad_token = tokenizer.eos_token
 
 # We then build the PPOTrainer, passing the model, the reference model, the tokenizer
 ppo_trainer = PPOTrainer(
-    config, model, ref_model=ref_model, tokenizer=tokenizer, dataset=dataset, data_collator=collator, optimizer=optimizer,
+    config,
+    model,
+    ref_model=ref_model,
+    tokenizer=tokenizer,
+    dataset=dataset,
+    data_collator=collator,
+    optimizer=optimizer,
 )
 
 # We then build the reward pipeline, we will use the toxicity model to compute the reward.

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -177,7 +177,9 @@ class PPOTrainer(BaseTrainer):
             )
         # Step 1: Initialize Accelerator
         self.accelerator = Accelerator(log_with=config.log_with, **config.accelerator_kwargs)
-        self.accelerator.init_trackers(config.tracker_project_name, config=config.to_dict(), init_kwargs=config.tracker_kwargs)
+        self.accelerator.init_trackers(
+            config.tracker_project_name, config=config.to_dict(), init_kwargs=config.tracker_kwargs
+        )
 
         self.model = model
         self.is_encoder_decoder = hasattr(self.model, "is_encoder_decoder")

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -177,7 +177,7 @@ class PPOTrainer(BaseTrainer):
             )
         # Step 1: Initialize Accelerator
         self.accelerator = Accelerator(log_with=config.log_with, **config.accelerator_kwargs)
-        self.accelerator.init_trackers(config.tracker_project_name, config=config.to_dict(), **config.tracker_kwargs)
+        self.accelerator.init_trackers(config.tracker_project_name, config=config.to_dict(), init_kwargs=config.tracker_kwargs)
 
         self.model = model
         self.is_encoder_decoder = hasattr(self.model, "is_encoder_decoder")


### PR DESCRIPTION
Two changes:
1. Pass the optimizer in the sentiment example (currently variable was not passed into trainier).
2. [I think] fix the kwarg option for wandb config of `Accelerate`. See this [docs page](https://docs.wandb.ai/guides/integrations/accelerate), where `init_kwargs` is handled differently. In trying to use this with the code as is, `wandb` is getting read as a `kwarg` and not handled correctly by [this line](https://github.com/lvwerra/trl/blob/b75d83ab28b59307916beb425207d46406502f11/trl/trainer/ppo_trainer.py#L180). If this is different in Tensorboard, it may just be incompatible.

Let me know if I'm wrong!

Fixes: #215