### PR TITLE
Grad accumulation and memory bugfix

### DIFF
--- a/examples/sentiment/scripts/gpt-neox-20b_peft/gpt-neo-20b_sentiment_peft.py
+++ b/examples/sentiment/scripts/gpt-neox-20b_peft/gpt-neo-20b_sentiment_peft.py
@@ -84,7 +84,7 @@ config = PPOConfig(
     log_with=script_args.log_with,
     mini_batch_size=script_args.mini_batch_size,
     batch_size=script_args.batch_size,
-    accelerator_kwargs=dict(gradient_accumulation_steps=script_args.gradient_accumulation_steps),
+    gradient_accumulation_steps=script_args.gradient_accumulation_steps,
 )
 
 # We then define the arguments to pass to the sentiment analysis pipeline.

--- a/examples/sentiment/scripts/gpt-neox-20b_peft/gpt-neo-20b_sentiment_peft.py
+++ b/examples/sentiment/scripts/gpt-neox-20b_peft/gpt-neo-20b_sentiment_peft.py
@@ -89,7 +89,7 @@ config = PPOConfig(
 
 # We then define the arguments to pass to the sentiment analysis pipeline.
 # We set `return_all_scores` to True to get the sentiment score for each token.
-sent_kwargs = {"return_all_scores": True, "function_to_apply": "none", "batch_size": config.forward_batch_size}
+sent_kwargs = {"return_all_scores": True, "function_to_apply": "none", "batch_size": config.mini_batch_size}
 
 
 # Below is an example function to build the dataset. In our case, we use the IMDB dataset

--- a/examples/sentiment/scripts/gpt-neox-20b_peft/gpt-neo-20b_sentiment_peft.py
+++ b/examples/sentiment/scripts/gpt-neox-20b_peft/gpt-neo-20b_sentiment_peft.py
@@ -62,13 +62,17 @@ class ScriptArguments:
     """
 
     # NOTE: gpt2 models use Conv1D instead of Linear layers which are not yet supported in 8 bit mode
-    # models like gpt-neo* models are more suitable
+    # models like gpt-neo* models are more suitable.
     model_name: Optional[str] = field(
         default="edbeeching/gpt-neo-125M-imdb-lora-adapter-merged", metadata={"help": "the model name"}
     )
     log_with: Optional[str] = field(default=None, metadata={"help": "use 'wandb' to log with wandb"})
     learning_rate: Optional[float] = field(default=1.41e-5, metadata={"help": "the learning rate"})
-    merge_model_adapter: Optional[bool] = field(default=False, metadata={"help": "the learning rate"})
+    mini_batch_size: Optional[int] = field(default=16, metadata={"help": "the PPO minibatch size"})
+    batch_size: Optional[int] = field(default=256, metadata={"help": "the batch size"})
+    gradient_accumulation_steps: Optional[int] = field(
+        default=1, metadata={"help": "the number of gradient accumulation steps"}
+    )
 
 
 parser = HfArgumentParser(ScriptArguments)
@@ -78,8 +82,9 @@ config = PPOConfig(
     model_name=script_args.model_name,
     learning_rate=script_args.learning_rate,
     log_with=script_args.log_with,
-    forward_batch_size=16,
-    batch_size=256,
+    mini_batch_size=script_args.mini_batch_size,
+    batch_size=script_args.batch_size,
+    accelerator_kwargs=dict(gradient_accumulation_steps=script_args.gradient_accumulation_steps),
 )
 
 # We then define the arguments to pass to the sentiment analysis pipeline.

--- a/examples/sentiment/scripts/gpt2-sentiment.py
+++ b/examples/sentiment/scripts/gpt2-sentiment.py
@@ -18,7 +18,7 @@ from typing import Optional
 import torch
 from datasets import load_dataset
 from tqdm import tqdm
-from transformers import AutoTokenizer, pipeline, HfArgumentParser
+from transformers import AutoTokenizer, HfArgumentParser, pipeline
 
 from trl import AutoModelForCausalLMWithValueHead, PPOConfig, PPOTrainer, set_seed
 from trl.core import LengthSampler

--- a/examples/sentiment/scripts/gpt2-sentiment.py
+++ b/examples/sentiment/scripts/gpt2-sentiment.py
@@ -12,10 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from dataclasses import dataclass, field
+from typing import Optional
+
 import torch
 from datasets import load_dataset
 from tqdm import tqdm
-from transformers import AutoTokenizer, pipeline
+from transformers import AutoTokenizer, pipeline, HfArgumentParser
 
 from trl import AutoModelForCausalLMWithValueHead, PPOConfig, PPOTrainer, set_seed
 from trl.core import LengthSampler
@@ -39,15 +42,43 @@ tqdm.pandas()
 #
 ########################################################################
 
+
 # We first define the configuration of the experiment, defining the model, the dataset,
 # the training parameters, and the PPO parameters.
 # Check the default arguments in the `PPOConfig` class for more details.
 # If you want to log with tensorboard, add the kwarg
 # `accelerator_kwargs={"logging_dir": PATH_TO_LOGS}` to the PPOConfig.
+# Define and parse arguments.
+@dataclass
+class ScriptArguments:
+    """
+    The name of the Casual LM model we wish to fine with PPO
+    """
+
+    # NOTE: gpt2 models use Conv1D instead of Linear layers which are not yet supported in 8 bit mode
+    # models like gpt-neo* models are more suitable.
+    model_name: Optional[str] = field(default="lvwerra/gpt2-imdb", metadata={"help": "the model name"})
+    log_with: Optional[str] = field(default=None, metadata={"help": "use 'wandb' to log with wandb"})
+    learning_rate: Optional[float] = field(default=1.41e-5, metadata={"help": "the learning rate"})
+    mini_batch_size: Optional[int] = field(default=16, metadata={"help": "the PPO minibatch size"})
+    batch_size: Optional[int] = field(default=256, metadata={"help": "the batch size"})
+    gradient_accumulation_steps: Optional[int] = field(
+        default=1, metadata={"help": "the number of gradient accumulation steps"}
+    )
+
+
+parser = HfArgumentParser(ScriptArguments)
+script_args = parser.parse_args_into_dataclasses()[0]
+
 config = PPOConfig(
-    model_name="lvwerra/gpt2-imdb",
-    learning_rate=1.41e-5,
+    model_name=script_args.model_name,
+    learning_rate=script_args.learning_rate,
+    log_with=script_args.log_with,
+    mini_batch_size=script_args.mini_batch_size,
+    batch_size=script_args.batch_size,
+    accelerator_kwargs=dict(gradient_accumulation_steps=script_args.gradient_accumulation_steps),
 )
+
 
 # We then define the arguments to pass to the sentiment analysis pipeline.
 # We set `return_all_scores` to True to get the sentiment score for each token.

--- a/examples/sentiment/scripts/gpt2-sentiment.py
+++ b/examples/sentiment/scripts/gpt2-sentiment.py
@@ -76,7 +76,7 @@ config = PPOConfig(
     log_with=script_args.log_with,
     mini_batch_size=script_args.mini_batch_size,
     batch_size=script_args.batch_size,
-    accelerator_kwargs=dict(gradient_accumulation_steps=script_args.gradient_accumulation_steps),
+    gradient_accumulation_steps=script_args.gradient_accumulation_steps,
 )
 
 

--- a/examples/sentiment/scripts/gpt2-sentiment_peft.py
+++ b/examples/sentiment/scripts/gpt2-sentiment_peft.py
@@ -86,7 +86,7 @@ config = PPOConfig(
     log_with=script_args.log_with,
     mini_batch_size=script_args.mini_batch_size,
     batch_size=script_args.batch_size,
-    accelerator_kwargs=dict(gradient_accumulation_steps=script_args.gradient_accumulation_steps),
+    gradient_accumulation_steps=script_args.gradient_accumulation_steps,
 )
 
 # We then define the arguments to pass to the sentiment analysis pipeline.

--- a/examples/sentiment/scripts/gpt2-sentiment_peft.py
+++ b/examples/sentiment/scripts/gpt2-sentiment_peft.py
@@ -70,6 +70,11 @@ class ScriptArguments:
     model_name: Optional[str] = field(default="edbeeching/gpt-neo-125M-imdb", metadata={"help": "the model name"})
     log_with: Optional[str] = field(default=None, metadata={"help": "use 'wandb' to log with wandb"})
     learning_rate: Optional[float] = field(default=1.41e-5, metadata={"help": "the learning rate"})
+    mini_batch_size: Optional[int] = field(default=16, metadata={"help": "the PPO minibatch size"})
+    batch_size: Optional[int] = field(default=256, metadata={"help": "the batch size"})
+    gradient_accumulation_steps: Optional[int] = field(
+        default=1, metadata={"help": "the number of gradient accumulation steps"}
+    )
 
 
 parser = HfArgumentParser(ScriptArguments)
@@ -79,8 +84,9 @@ config = PPOConfig(
     model_name=script_args.model_name,
     learning_rate=script_args.learning_rate,
     log_with=script_args.log_with,
-    mini_batch_size=16,
-    batch_size=256,
+    mini_batch_size=script_args.mini_batch_size,
+    batch_size=script_args.batch_size,
+    accelerator_kwargs=dict(gradient_accumulation_steps=script_args.gradient_accumulation_steps),
 )
 
 # We then define the arguments to pass to the sentiment analysis pipeline.

--- a/examples/sentiment/scripts/t5-sentiment.py
+++ b/examples/sentiment/scripts/t5-sentiment.py
@@ -16,11 +16,10 @@
 from dataclasses import dataclass, field
 from typing import Optional
 
-
 import torch
 from datasets import load_dataset
 from tqdm import tqdm
-from transformers import AutoTokenizer, pipeline, HfArgumentParser
+from transformers import AutoTokenizer, HfArgumentParser, pipeline
 
 from trl import AutoModelForSeq2SeqLMWithValueHead, PPOConfig, PPOTrainer, set_seed
 from trl.core import LengthSampler

--- a/examples/sentiment/scripts/t5-sentiment.py
+++ b/examples/sentiment/scripts/t5-sentiment.py
@@ -12,10 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
 import torch
 from datasets import load_dataset
 from tqdm import tqdm
-from transformers import AutoTokenizer, pipeline
+from transformers import AutoTokenizer, pipeline, HfArgumentParser
 
 from trl import AutoModelForSeq2SeqLMWithValueHead, PPOConfig, PPOTrainer, set_seed
 from trl.core import LengthSampler
@@ -40,10 +45,39 @@ tqdm.pandas()
 #
 ########################################################################
 
+
 # We first define the configuration of the experiment, defining the model, the dataset,
 # the training parameters, and the PPO parameters.
 # Check the default arguments in the `PPOConfig` class for more details.
-config = PPOConfig(model_name="lvwerra/t5-imdb", learning_rate=5e-5, batch_size=256)
+@dataclass
+class ScriptArguments:
+    """
+    The name of the Casual LM model we wish to fine with PPO
+    """
+
+    # NOTE: gpt2 models use Conv1D instead of Linear layers which are not yet supported in 8 bit mode
+    # models like gpt-neo* models are more suitable.
+    model_name: Optional[str] = field(default="lvwerra/t5-imdb", metadata={"help": "the model name"})
+    log_with: Optional[str] = field(default=None, metadata={"help": "use 'wandb' to log with wandb"})
+    learning_rate: Optional[float] = field(default=5e-5, metadata={"help": "the learning rate"})
+    mini_batch_size: Optional[int] = field(default=16, metadata={"help": "the PPO minibatch size"})
+    batch_size: Optional[int] = field(default=256, metadata={"help": "the batch size"})
+    gradient_accumulation_steps: Optional[int] = field(
+        default=1, metadata={"help": "the number of gradient accumulation steps"}
+    )
+
+
+parser = HfArgumentParser(ScriptArguments)
+script_args = parser.parse_args_into_dataclasses()[0]
+
+config = PPOConfig(
+    model_name=script_args.model_name,
+    learning_rate=script_args.learning_rate,
+    log_with=script_args.log_with,
+    mini_batch_size=script_args.mini_batch_size,
+    batch_size=script_args.batch_size,
+    accelerator_kwargs=dict(gradient_accumulation_steps=script_args.gradient_accumulation_steps),
+)
 # We then define the arguments to pass to the sentiment analysis pipeline.
 # We set `return_all_scores` to True to get the sentiment score for each token.
 sent_kwargs = {"return_all_scores": True, "function_to_apply": "none", "batch_size": 16}

--- a/examples/sentiment/scripts/t5-sentiment.py
+++ b/examples/sentiment/scripts/t5-sentiment.py
@@ -75,7 +75,7 @@ config = PPOConfig(
     log_with=script_args.log_with,
     mini_batch_size=script_args.mini_batch_size,
     batch_size=script_args.batch_size,
-    accelerator_kwargs=dict(gradient_accumulation_steps=script_args.gradient_accumulation_steps),
+    gradient_accumulation_steps=script_args.gradient_accumulation_steps,
 )
 # We then define the arguments to pass to the sentiment analysis pipeline.
 # We set `return_all_scores` to True to get the sentiment score for each token.

--- a/examples/toxicity/scripts/gpt-j-6b-toxicity.py
+++ b/examples/toxicity/scripts/gpt-j-6b-toxicity.py
@@ -12,11 +12,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from dataclasses import dataclass, field
+from typing import Optional
+
 import torch
 from datasets import load_dataset
 from torch.optim import Adam
 from tqdm import tqdm
-from transformers import AutoModelForCausalLM, AutoTokenizer, RobertaForSequenceClassification, RobertaTokenizer
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    RobertaForSequenceClassification,
+    RobertaTokenizer,
+    HfArgumentParser,
+)
 
 from trl import AutoModelForCausalLMWithValueHead, PPOConfig, PPOTrainer, create_reference_model, set_seed
 from trl.core import LengthSampler
@@ -41,17 +50,40 @@ tqdm.pandas()
 #
 ########################################################################
 
+
 # We first define the configuration of the experiment, defining the model, the dataset,
 # the training parameters, and the PPO parameters.
 # Check the default arguments in the `PPOConfig` class for more details.
 # If you want to log with tensorboard, add the kwarg
 # `accelerator_kwargs={"logging_dir": PATH_TO_LOGS}` to the PPOConfig.
+@dataclass
+class ScriptArguments:
+    """
+    The name of the Casual LM model we wish to fine with PPO
+    """
+
+    # NOTE: gpt2 models use Conv1D instead of Linear layers which are not yet supported in 8 bit mode
+    # models like gpt-neo* models are more suitable.
+    model_name: Optional[str] = field(default="ybelkada/gpt-j-6b-sharded-bf16", metadata={"help": "the model name"})
+    log_with: Optional[str] = field(default=None, metadata={"help": "use 'wandb' to log with wandb"})
+    learning_rate: Optional[float] = field(default=(1.47e-5) * 2, metadata={"help": "the learning rate"})
+    mini_batch_size: Optional[int] = field(default=1, metadata={"help": "the PPO minibatch size"})
+    batch_size: Optional[int] = field(default=256, metadata={"help": "the batch size"})
+    gradient_accumulation_steps: Optional[int] = field(
+        default=1, metadata={"help": "the number of gradient accumulation steps"}
+    )
+
+
+parser = HfArgumentParser(ScriptArguments)
+script_args = parser.parse_args_into_dataclasses()[0]
+
 config = PPOConfig(
-    model_name="ybelkada/gpt-j-6b-sharded-bf16",
-    learning_rate=(1.47e-5) * 2,
-    log_with="wandb",
-    batch_size=32,
-    forward_batch_size=1,
+    model_name=script_args.model_name,
+    learning_rate=script_args.learning_rate,
+    log_with=script_args.log_with,
+    mini_batch_size=script_args.mini_batch_size,
+    batch_size=script_args.batch_size,
+    accelerator_kwargs=dict(gradient_accumulation_steps=script_args.gradient_accumulation_steps),
 )
 
 

--- a/examples/toxicity/scripts/gpt-j-6b-toxicity.py
+++ b/examples/toxicity/scripts/gpt-j-6b-toxicity.py
@@ -83,7 +83,7 @@ config = PPOConfig(
     log_with=script_args.log_with,
     mini_batch_size=script_args.mini_batch_size,
     batch_size=script_args.batch_size,
-    accelerator_kwargs=dict(gradient_accumulation_steps=script_args.gradient_accumulation_steps),
+    gradient_accumulation_steps=script_args.gradient_accumulation_steps,
 )
 
 

--- a/examples/toxicity/scripts/gpt-j-6b-toxicity.py
+++ b/examples/toxicity/scripts/gpt-j-6b-toxicity.py
@@ -22,9 +22,9 @@ from tqdm import tqdm
 from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
+    HfArgumentParser,
     RobertaForSequenceClassification,
     RobertaTokenizer,
-    HfArgumentParser,
 )
 
 from trl import AutoModelForCausalLMWithValueHead, PPOConfig, PPOTrainer, create_reference_model, set_seed

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -56,6 +56,8 @@ class PPOConfig(object):
             Number of samples forward passed through model at a time
         mini_batch_size (`int`, *optional*, defaults to 1):
             Number of samples optimized inside PPO together
+        gradient_accumulation_steps (`int`, *optional*, defaults to 1):
+            The number of gradient accumulation steps
         ppo_epochs (`int`, *optional*, defaults to 4):
             Number of optimisation epochs per batch of samples
         remove_unused_columns (`bool`, *optional*, defaults to True):
@@ -94,6 +96,7 @@ class PPOConfig(object):
         batch_size: Optional[int] = 256,
         forward_batch_size: Optional[int] = None,
         mini_batch_size: Optional[int] = 1,
+        gradient_accumulation_steps: Optional[int] = 1,
         ppo_epochs: Optional[int] = 4,
         remove_unused_columns: Optional[bool] = True,
         log_with: Optional[str] = None,
@@ -124,6 +127,7 @@ class PPOConfig(object):
             self.mini_batch_size = forward_batch_size
         else:
             self.mini_batch_size = mini_batch_size
+        self.gradient_accumulation_steps = gradient_accumulation_steps
         self.ppo_epochs = ppo_epochs
         self.remove_unused_columns = remove_unused_columns
         self.seed = seed

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -182,7 +182,7 @@ class PPOTrainer(BaseTrainer):
             gradient_accumulation_steps=config.gradient_accumulation_steps,
             **config.accelerator_kwargs,
         )
-        self.accelerator.init_trackers(config.tracker_project_name, config=config.to_dict(), **config.tracker_kwargs)
+        self.accelerator.init_trackers(config.tracker_project_name, config=config.to_dict(), init_kwargs=config.tracker_kwargs)
 
         self.model = model
         self.is_encoder_decoder = hasattr(self.model, "is_encoder_decoder")

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -800,7 +800,9 @@ class PPOTrainer(BaseTrainer):
         advantages = masked_whiten(advantages, mask)
         advantages = advantages.detach()
 
-        vpredclipped = clip_by_value(vpreds, values - self.config.cliprange_value, values + self.config.cliprange_value)
+        vpredclipped = clip_by_value(
+            vpreds, values - self.config.cliprange_value, values + self.config.cliprange_value
+        )
 
         vf_losses1 = (vpreds - returns) ** 2
         vf_losses2 = (vpredclipped - returns) ** 2

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -798,7 +798,9 @@ class PPOTrainer(BaseTrainer):
         advantages = masked_whiten(advantages, mask)
         advantages = advantages.detach()
 
-        vpredclipped = clip_by_value(vpreds, values - self.config.cliprange_value, values + self.config.cliprange_value)
+        vpredclipped = clip_by_value(
+            vpreds, values - self.config.cliprange_value, values + self.config.cliprange_value
+        )
 
         vf_losses1 = (vpreds - returns) ** 2
         vf_losses2 = (vpredclipped - returns) ** 2

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -798,9 +798,7 @@ class PPOTrainer(BaseTrainer):
         advantages = masked_whiten(advantages, mask)
         advantages = advantages.detach()
 
-        vpredclipped = clip_by_value(
-            vpreds, values - self.config.cliprange_value, values + self.config.cliprange_value
-        )
+        vpredclipped = clip_by_value(vpreds, values - self.config.cliprange_value, values + self.config.cliprange_value)
 
         vf_losses1 = (vpreds - returns) ** 2
         vf_losses2 = (vpredclipped - returns) ** 2
@@ -823,23 +821,23 @@ class PPOTrainer(BaseTrainer):
         value_mean, value_var = masked_mean(values, mask), masked_var(values, mask)
 
         stats = dict(
-            loss=dict(policy=pg_loss, value=vf_loss, total=loss),
+            loss=dict(policy=pg_loss.detach(), value=vf_loss.detach(), total=loss.detach()),
             policy=dict(
-                entropy=entropy,
-                approxkl=approxkl,
-                policykl=policykl,
-                clipfrac=pg_clipfrac,
-                advantages=advantages,
-                advantages_mean=masked_mean(advantages, mask),
+                entropy=entropy.detach(),
+                approxkl=approxkl.detach(),
+                policykl=policykl.detach(),
+                clipfrac=pg_clipfrac.detach(),
+                advantages=advantages.detach(),
+                advantages_mean=masked_mean(advantages, mask).detach(),
                 ratio=ratio,
             ),
-            returns=dict(mean=return_mean, var=return_var),
+            returns=dict(mean=return_mean.detach(), var=return_var.detach()),
             val=dict(
-                vpred=masked_mean(vpreds, mask),
-                error=masked_mean((vpreds - returns) ** 2, mask),
-                clipfrac=vf_clipfrac,
-                mean=value_mean,
-                var=value_var,
+                vpred=masked_mean(vpreds, mask).detach(),
+                error=masked_mean((vpreds - returns) ** 2, mask).detach(),
+                clipfrac=vf_clipfrac.detach(),
+                mean=value_mean.detach(),
+                var=value_var.detach(),
             ),
         )
         return pg_loss, self.config.vf_coef * vf_loss, flatten_dict(stats)

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -182,7 +182,9 @@ class PPOTrainer(BaseTrainer):
             gradient_accumulation_steps=config.gradient_accumulation_steps,
             **config.accelerator_kwargs,
         )
-        self.accelerator.init_trackers(config.tracker_project_name, config=config.to_dict(), init_kwargs=config.tracker_kwargs)
+        self.accelerator.init_trackers(
+            config.tracker_project_name, config=config.to_dict(), init_kwargs=config.tracker_kwargs
+        )
 
         self.model = model
         self.is_encoder_decoder = hasattr(self.model, "is_encoder_decoder")


### PR DESCRIPTION
- Adds command line arg passing to sentiment and toxicity examples
- Adds gradient accumulation as a command line arg #218 
- Fixes tensors not being detached from graph when stored in stats, leading to an overuse of memory.
- Updates forward_batch_size -> minibatch size in a number of examples

By the way, I think there may be other places we use excessive memory due to storing attached tensors for too long. I will investigate further.