### PR TITLE
[`test`] attempt to fix CI test for PT 2.0

### DIFF
--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -27,6 +27,7 @@ from transformers import AutoTokenizer
 
 from trl import AutoModelForCausalLMWithValueHead, AutoModelForSeq2SeqLMWithValueHead, PPOConfig, PPOTrainer, set_seed
 from trl.core import respond_to_batch
+from trl.import_utils import is_torch_greater_2_0
 
 from .testing_constants import CI_HUB_ENDPOINT, CI_HUB_USER, CI_HUB_USER_TOKEN
 from .testing_utils import require_peft, require_torch_multi_gpu
@@ -264,7 +265,10 @@ class PPOTrainerTester(unittest.TestCase):
         dummy_dataloader = ppo_trainer.dataloader
 
         self.assertTrue(isinstance(ppo_trainer.optimizer.optimizer, torch.optim.SGD))
-        self.assertTrue(isinstance(ppo_trainer.lr_scheduler.scheduler, torch.optim.lr_scheduler.ExponentialLR))
+        if is_torch_greater_2_0():
+            self.assertTrue(isinstance(ppo_trainer.lr_scheduler, torch.optim.lr_scheduler.ExponentialLR))
+        else:
+            self.assertTrue(isinstance(ppo_trainer.lr_scheduler.scheduler, torch.optim.lr_scheduler.ExponentialLR))
 
         # train model with ppo
         for query_tensor, response_tensor in dummy_dataloader:

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -246,7 +246,6 @@ class PPOTrainerTester(unittest.TestCase):
         for stat in EXPECTED_STATS:
             assert stat in train_stats.keys()
 
-    @unittest.skip("TODO: fix this test")
     def test_ppo_step_with_no_ref_sgd_lr_scheduler(self):
         # initialize dataset
         dummy_dataset = self._init_dummy_dataset()

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -265,10 +265,11 @@ class PPOTrainerTester(unittest.TestCase):
         dummy_dataloader = ppo_trainer.dataloader
 
         self.assertTrue(isinstance(ppo_trainer.optimizer.optimizer, torch.optim.SGD))
-        if is_torch_greater_2_0():
-            self.assertTrue(isinstance(ppo_trainer.lr_scheduler, torch.optim.lr_scheduler.ExponentialLR))
-        else:
+        # for some accelerate versions the scheduler is not an `Accelerate scheduler` object
+        if hasattr(ppo_trainer.lr_scheduler, "scheduler"):
             self.assertTrue(isinstance(ppo_trainer.lr_scheduler.scheduler, torch.optim.lr_scheduler.ExponentialLR))
+        else:
+            self.assertTrue(isinstance(ppo_trainer.lr_scheduler, torch.optim.lr_scheduler.ExponentialLR))
 
         # train model with ppo
         for query_tensor, response_tensor in dummy_dataloader:

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -265,10 +265,7 @@ class PPOTrainerTester(unittest.TestCase):
 
         self.assertTrue(isinstance(ppo_trainer.optimizer.optimizer, torch.optim.SGD))
         # for some accelerate versions the scheduler is not an `Accelerate scheduler` object
-        if hasattr(ppo_trainer.lr_scheduler, "scheduler"):
-            self.assertTrue(isinstance(ppo_trainer.lr_scheduler.scheduler, torch.optim.lr_scheduler.ExponentialLR))
-        else:
-            self.assertTrue(isinstance(ppo_trainer.lr_scheduler, torch.optim.lr_scheduler.ExponentialLR))
+        self.assertTrue(isinstance(ppo_trainer.lr_scheduler.scheduler, torch.optim.lr_scheduler.ExponentialLR))
 
         # train model with ppo
         for query_tensor, response_tensor in dummy_dataloader:

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -27,7 +27,6 @@ from transformers import AutoTokenizer
 
 from trl import AutoModelForCausalLMWithValueHead, AutoModelForSeq2SeqLMWithValueHead, PPOConfig, PPOTrainer, set_seed
 from trl.core import respond_to_batch
-from trl.import_utils import is_torch_greater_2_0
 
 from .testing_constants import CI_HUB_ENDPOINT, CI_HUB_USER, CI_HUB_USER_TOKEN
 from .testing_utils import require_peft, require_torch_multi_gpu

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -264,7 +264,6 @@ class PPOTrainerTester(unittest.TestCase):
         dummy_dataloader = ppo_trainer.dataloader
 
         self.assertTrue(isinstance(ppo_trainer.optimizer.optimizer, torch.optim.SGD))
-        # for some accelerate versions the scheduler is not an `Accelerate scheduler` object
         self.assertTrue(isinstance(ppo_trainer.lr_scheduler.scheduler, torch.optim.lr_scheduler.ExponentialLR))
 
         # train model with ppo

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib
+from importlib.metadata import version
 
 
 def is_peft_available():
     return importlib.util.find_spec("peft") is not None
+
+
+def is_torch_greater_2_0():
+    torch_version = version("torch")
+    return torch_version >= "2.0"

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib
-from importlib.metadata import version
+import sys
+
+
+if sys.version_info[0] < 3.8:
+    _is_python_greater_3_8 = False
+else:
+    _is_python_greater_3_8 = True
 
 
 def is_peft_available():
@@ -20,5 +26,12 @@ def is_peft_available():
 
 
 def is_torch_greater_2_0():
-    torch_version = version("torch")
+    if _is_python_greater_3_8:
+        from importlib.metadata import version
+
+        torch_version = version("torch")
+    else:
+        import pkg_resources
+
+        torch_version = pkg_resources.get_distribution("torch").version
     return torch_version >= "2.0"


### PR DESCRIPTION
# What does this PR do?

This PR fixes the failing tests related to Pytorch 2.0 upgrade

In Pytorch 2.0, the learning rate schedulers have been re-designed, thus we need a bit of refactoring on `trl` to deal with unexpected behaviors.

In Pytorch 2.0 it seems that the class `_LRScheduler` have been deprecated in favor of `LRScheduler`

## In Pytorch 2.0:

```python
# Including _LRScheduler for backwards compatibility
# Subclass instead of assign because we want __name__ of _LRScheduler to be _LRScheduler (assigning would make it LRScheduler).
class _LRScheduler(LRScheduler):
    pass
```

## In Pytorch < 2.0:

```python

class LambdaLR(_LRScheduler):
    """Sets the learning rate of each parameter group to the initial lr
    times a given function. When last_epoch=-1, sets initial lr as lr.

    Args:"""
```

Hence the check `isinstance(lr_scheduler, torch.optim.lr_scheduler._LRScheduler)` does not pass anymore with Pytorch >=2.0