### PR TITLE
[`core`] refactor peft API

### DIFF
--- a/docs/source/sentiment_tuning_peft.mdx
+++ b/docs/source/sentiment_tuning_peft.mdx
@@ -26,6 +26,30 @@ pip install wandb
 
 Note: if you don't want to log with `wandb` remove `log_with="wandb"` in the scripts/notebooks. You can also replace it with your favourite experiment tracker that's [supported by `accelerate`](https://huggingface.co/docs/accelerate/usage_guides/tracking).
 
+## How to use it?
+
+Simply declare a `PeftConfig` object in your script and pass it through `.from_pretrained` to load the TRL+PEFT model. 
+
+```python
+from peft import LoraConfig
+from trl import AutoModelForCausalLMWithValueHead
+
+model_id = "edbeeching/gpt-neo-125M-imdb"
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    lora_dropout=0.05,
+    bias="none",
+    task_type="CAUSAL_LM",
+)
+
+model = AutoModelForCausalLMWithValueHead.from_pretrained(
+    model_id, 
+    load_in_8bit=True, 
+    peft_config=lora_config,
+)
+```
+
 
 ## Launch scripts
 
@@ -40,13 +64,21 @@ accelerate launch scripts/gpt2-sentiment_peft.py # launches training
 
 You can scale up to as many GPUs as you want, as long as you are able to fit the training process in a single device. The only tweak you need to apply is to load the model as follows:
 ```python
-from accelerate import Accelerator
+from peft import LoraConfig
 ...
 
-current_device = Accelerator().process_index
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    lora_dropout=0.05,
+    bias="none",
+    task_type="CAUSAL_LM",
+)
 
 pretrained_model = AutoModelForCausalLM.from_pretrained(
-    config.model_name, load_in_8bit=True, device_map={"": current_device}
+    config.model_name, 
+    load_in_8bit=True, 
+    peft_config=lora_config,
 )
 ```
 The reason behind `device_map={"": current_device}` is that when you set `"":device_number`, `accelerate` will set the entire model on the `device_number` device. Therefore this trick enables to set the model on the correct device for each process.

--- a/docs/source/sentiment_tuning_peft.mdx
+++ b/docs/source/sentiment_tuning_peft.mdx
@@ -45,16 +45,15 @@ lora_config = LoraConfig(
 
 model = AutoModelForCausalLMWithValueHead.from_pretrained(
     model_id, 
-    load_in_8bit=True, 
     peft_config=lora_config,
 )
 ```
 And if you want to load your model in 8bit precision:
 ```python
-pretrained_model = AutoModelForCausalLM.from_pretrained(
+pretrained_model = AutoModelForCausalLMWithValueHead.from_pretrained(
     config.model_name, 
-    peft_config=lora_config,
     load_in_8bit=True,
+    peft_config=lora_config,
 )
 ```
 
@@ -83,14 +82,14 @@ lora_config = LoraConfig(
     task_type="CAUSAL_LM",
 )
 
-pretrained_model = AutoModelForCausalLM.from_pretrained(
+pretrained_model = AutoModelForCausalLMWithValueHead.from_pretrained(
     config.model_name, 
     peft_config=lora_config,
 )
 ```
 And if you want to load your model in 8bit precision:
 ```python
-pretrained_model = AutoModelForCausalLM.from_pretrained(
+pretrained_model = AutoModelForCausalLMWithValueHead.from_pretrained(
     config.model_name, 
     peft_config=lora_config,
     load_in_8bit=True,

--- a/docs/source/sentiment_tuning_peft.mdx
+++ b/docs/source/sentiment_tuning_peft.mdx
@@ -49,6 +49,14 @@ model = AutoModelForCausalLMWithValueHead.from_pretrained(
     peft_config=lora_config,
 )
 ```
+And if you want to load your model in 8bit precision:
+```python
+pretrained_model = AutoModelForCausalLM.from_pretrained(
+    config.model_name, 
+    peft_config=lora_config,
+    load_in_8bit=True,
+)
+```
 
 
 ## Launch scripts
@@ -89,12 +97,7 @@ pretrained_model = AutoModelForCausalLM.from_pretrained(
 )
 ```
 
-The reason behind `device_map={"": current_device}` is that when you set `"":device_number`, `accelerate` will set the entire model on the `device_number` device. Therefore this trick enables to set the model on the correct device for each process.
-
-As the `Accelerator` object from `accelerate` will take care of initializing the distributed setup correctly.
-Make sure to initialize your accelerate config by specifying that you are training in a multi-gpu setup, by running `accelerate config` and make sure to run the training script with `accelerator launch your_script.py`.
-
-Finally make sure that the rewards are computed on `current_device` as well.
+Finally make sure that the rewards are computed on correct device as well, for that you can use `ppo_trainer.model.current_device`.
 
 ## Naive pipeline parallelism (NPP) for large models (>60B models)
 

--- a/docs/source/sentiment_tuning_peft.mdx
+++ b/docs/source/sentiment_tuning_peft.mdx
@@ -77,10 +77,18 @@ lora_config = LoraConfig(
 
 pretrained_model = AutoModelForCausalLM.from_pretrained(
     config.model_name, 
-    load_in_8bit=True, 
     peft_config=lora_config,
 )
 ```
+And if you want to load your model in 8bit precision:
+```python
+pretrained_model = AutoModelForCausalLM.from_pretrained(
+    config.model_name, 
+    peft_config=lora_config,
+    load_in_8bit=True,
+)
+```
+
 The reason behind `device_map={"": current_device}` is that when you set `"":device_number`, `accelerate` will set the entire model on the `device_number` device. Therefore this trick enables to set the model on the correct device for each process.
 
 As the `Accelerator` object from `accelerate` will take care of initializing the distributed setup correctly.

--- a/examples/sentiment/scripts/gpt-neo-1b-multi-gpu/gpt-neo-1b_peft.py
+++ b/examples/sentiment/scripts/gpt-neo-1b-multi-gpu/gpt-neo-1b_peft.py
@@ -17,9 +17,9 @@ from typing import Optional
 
 import torch
 from datasets import load_dataset
+from peft import LoraConfig
 from tqdm import tqdm
 from transformers import AutoTokenizer, HfArgumentParser, pipeline
-from peft import LoraConfig
 
 from trl import AutoModelForCausalLMWithValueHead, PPOConfig, PPOTrainer, set_seed
 from trl.core import LengthSampler

--- a/examples/sentiment/scripts/gpt-neo-1b-multi-gpu/gpt-neo-1b_peft.py
+++ b/examples/sentiment/scripts/gpt-neo-1b-multi-gpu/gpt-neo-1b_peft.py
@@ -17,9 +17,9 @@ from typing import Optional
 
 import torch
 from datasets import load_dataset
-from peft import LoraConfig, get_peft_model, prepare_model_for_int8_training
 from tqdm import tqdm
-from transformers import AutoModelForCausalLM, AutoTokenizer, HfArgumentParser, pipeline
+from transformers import AutoTokenizer, HfArgumentParser, pipeline
+from peft import LoraConfig
 
 from trl import AutoModelForCausalLMWithValueHead, PPOConfig, PPOTrainer, set_seed
 from trl.core import LengthSampler
@@ -63,7 +63,7 @@ class ScriptArguments:
 
     # NOTE: gpt2 models use Conv1D instead of Linear layers which are not yet supported in 8 bit mode
     # models like gpt-neo* models are more suitable
-    model_name: Optional[str] = field(default="EleutherAI/gpt-neox-20b", metadata={"help": "the model name"})
+    model_name: Optional[str] = field(default="edbeeching/gpt-neo-1.3B-imdb", metadata={"help": "the model name"})
     log_with: Optional[str] = field(default=None, metadata={"help": "use 'wandb' to log with wandb"})
     learning_rate: Optional[float] = field(default=1.41e-5, metadata={"help": "the learning rate"})
     merge_model_adapter: Optional[bool] = field(default=False, metadata={"help": "the learning rate"})
@@ -162,15 +162,14 @@ lora_config = LoraConfig(
 )
 
 # Now let's build the model, the reference model, and the tokenizer.
-pretrained_model = AutoModelForCausalLM.from_pretrained(
-    config.model_name, load_in_8bit=True, device_map="balanced", max_memory={0: "800MB", 1: "800MB"}
+model = AutoModelForCausalLMWithValueHead.from_pretrained(
+    config.model_name,
+    load_in_8bit=True,
+    device_map="balanced",
+    max_memory={0: "800MB", 1: "800MB"},
+    peft_config=lora_config,
 )
 tokenizer = AutoTokenizer.from_pretrained(config.model_name)
-
-pretrained_model = prepare_model_for_int8_training(pretrained_model)
-pretrained_model = get_peft_model(pretrained_model, lora_config)
-
-model = AutoModelForCausalLMWithValueHead.from_pretrained(pretrained_model)
 
 print_trainable_parameters(model)
 

--- a/examples/sentiment/scripts/gpt2-sentiment_peft.py
+++ b/examples/sentiment/scripts/gpt2-sentiment_peft.py
@@ -18,9 +18,9 @@ from typing import Optional
 import torch
 from accelerate import Accelerator
 from datasets import load_dataset
-from peft import LoraConfig, get_peft_model, prepare_model_for_int8_training
+from peft import LoraConfig
 from tqdm import tqdm
-from transformers import AutoModelForCausalLM, AutoTokenizer, HfArgumentParser, pipeline
+from transformers import AutoTokenizer, HfArgumentParser, pipeline
 
 from trl import AutoModelForCausalLMWithValueHead, PPOConfig, PPOTrainer, set_seed
 from trl.core import LengthSampler
@@ -144,8 +144,16 @@ set_seed(config.seed)
 # Now let's build the main base model! We'll use the `AutoModelForCausalLM` class and load the model in 8 bit mode.
 current_device = Accelerator().process_index
 
-pretrained_model = AutoModelForCausalLM.from_pretrained(
-    config.model_name, load_in_8bit=True, device_map={"": current_device}
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    lora_dropout=0.05,
+    bias="none",
+    task_type="CAUSAL_LM",
+)
+
+model = AutoModelForCausalLMWithValueHead.from_pretrained(
+    config.model_name, load_in_8bit=True, device_map={"": current_device}, peft_config=lora_config, layer_norm_names=[]
 )
 
 tokenizer = AutoTokenizer.from_pretrained(config.model_name)
@@ -168,18 +176,6 @@ def print_trainable_parameters(model):
     )
 
 
-lora_config = LoraConfig(
-    r=16,
-    lora_alpha=32,
-    lora_dropout=0.05,
-    bias="none",
-    task_type="CAUSAL_LM",
-)
-
-pretrained_model = prepare_model_for_int8_training(pretrained_model, layer_norm_names=[])
-pretrained_model = get_peft_model(pretrained_model, lora_config)
-
-model = AutoModelForCausalLMWithValueHead.from_pretrained(pretrained_model)
 print_trainable_parameters(model)
 model.train()
 

--- a/examples/sentiment/scripts/gpt2-sentiment_peft.py
+++ b/examples/sentiment/scripts/gpt2-sentiment_peft.py
@@ -174,9 +174,7 @@ def print_trainable_parameters(model):
         f"trainable params: {trainable_params} || all params: {all_param} || trainable%: {100 * trainable_params / all_param}"
     )
 
-
 print_trainable_parameters(model)
-model.train()
 
 # GPT-2 tokenizer has a pad token, but it is not eos_token by default. We need to set it to eos_token.
 # only for this model.

--- a/examples/sentiment/scripts/gpt2-sentiment_peft.py
+++ b/examples/sentiment/scripts/gpt2-sentiment_peft.py
@@ -174,6 +174,7 @@ def print_trainable_parameters(model):
         f"trainable params: {trainable_params} || all params: {all_param} || trainable%: {100 * trainable_params / all_param}"
     )
 
+
 print_trainable_parameters(model)
 
 # GPT-2 tokenizer has a pad token, but it is not eos_token by default. We need to set it to eos_token.

--- a/tests/test_peft_models.py
+++ b/tests/test_peft_models.py
@@ -25,7 +25,7 @@ from trl import AutoModelForCausalLMWithValueHead, is_peft_available
 if is_peft_available():
     from peft import get_peft_model, LoraConfig
 
-from .testing_utils import require_peft
+from .testing_utils import require_bitsandbytes, require_peft
 
 
 @require_peft
@@ -96,6 +96,34 @@ class PeftModelTester(unittest.TestCase):
         # Check that the number of trainable parameters is correct
         nb_trainable_params = sum(p.numel() for p in trl_model.parameters() if p.requires_grad)
         self.assertEqual(nb_trainable_params, 10273)
+
+    @require_bitsandbytes
+    def test_create_bnb_peft_model_from_config(self):
+        r"""
+        Simply creates a peft model and checks that it can be loaded.
+        """
+        from bitsandbytes.nn import Linear8bitLt
+
+        trl_model = AutoModelForCausalLMWithValueHead.from_pretrained(
+            self.causal_lm_model_id, peft_config=self.lora_config, load_in_8bit=True
+        )
+        # Check that the number of trainable parameters is correct
+        nb_trainable_params = sum(p.numel() for p in trl_model.parameters() if p.requires_grad)
+        self.assertEqual(nb_trainable_params, 10273)
+        self.assertTrue(
+            trl_model.pretrained_model.model.gpt_neox.layers[0].mlp.dense_h_to_4h.__class__ == Linear8bitLt
+        )
+
+        causal_lm_model = AutoModelForCausalLM.from_pretrained(
+            self.causal_lm_model_id, load_in_8bit=True, device_map="auto"
+        )
+        trl_model = AutoModelForCausalLMWithValueHead.from_pretrained(causal_lm_model, peft_config=self.lora_config)
+        # Check that the number of trainable parameters is correct
+        nb_trainable_params = sum(p.numel() for p in trl_model.parameters() if p.requires_grad)
+        self.assertEqual(nb_trainable_params, 10273)
+        self.assertTrue(
+            trl_model.pretrained_model.model.gpt_neox.layers[0].mlp.dense_h_to_4h.__class__ == Linear8bitLt
+        )
 
     def test_save_pretrained_peft(self):
         r"""

--- a/tests/test_peft_models.py
+++ b/tests/test_peft_models.py
@@ -80,6 +80,23 @@ class PeftModelTester(unittest.TestCase):
         nb_trainable_params = sum(p.numel() for p in non_peft_model.parameters() if p.requires_grad)
         self.assertEqual(nb_trainable_params, 99578)
 
+    def test_create_peft_model_from_config(self):
+        r"""
+        Simply creates a peft model and checks that it can be loaded.
+        """
+        trl_model = AutoModelForCausalLMWithValueHead.from_pretrained(
+            self.causal_lm_model_id, peft_config=self.lora_config
+        )
+        # Check that the number of trainable parameters is correct
+        nb_trainable_params = sum(p.numel() for p in trl_model.parameters() if p.requires_grad)
+        self.assertEqual(nb_trainable_params, 10273)
+
+        causal_lm_model = AutoModelForCausalLM.from_pretrained(self.causal_lm_model_id)
+        trl_model = AutoModelForCausalLMWithValueHead.from_pretrained(causal_lm_model, peft_config=self.lora_config)
+        # Check that the number of trainable parameters is correct
+        nb_trainable_params = sum(p.numel() for p in trl_model.parameters() if p.requires_grad)
+        self.assertEqual(nb_trainable_params, 10273)
+
     def test_save_pretrained_peft(self):
         r"""
         Check that the model can be saved and loaded properly.

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -27,6 +27,17 @@ def require_peft(test_case):
     return test_case
 
 
+def require_bitsandbytes(test_case):
+    """
+    Decorator marking a test that requires bitsandbytes. Skips the test if bitsandbytes is not available.
+    """
+    try:
+        import bitsandbytes  # noqa: F401
+    except ImportError:
+        test_case = unittest.skip("test requires bitsandbytes")(test_case)
+    return test_case
+
+
 def require_torch_multi_gpu(test_case):
     """
     Decorator marking a test that requires multiple GPUs. Skips the test if there aren't enough GPUs.

--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -112,7 +112,10 @@ class PreTrainedModelWrapper(nn.Module):
 
         is_peft_model = False
         current_device = cls._get_current_device()
-        is_loaded_in_8bit = pretrained_kwargs.pop("load_in_8bit", False)
+        if isinstance(pretrained_model_name_or_path, str):
+            is_loaded_in_8bit = pretrained_kwargs.pop("load_in_8bit", False)
+        else:
+            is_loaded_in_8bit = getattr(pretrained_model_name_or_path, "is_loaded_in_8bit", False)
 
         if is_loaded_in_8bit and "device_map" not in pretrained_kwargs:
             # warn users

--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -113,7 +113,7 @@ class PreTrainedModelWrapper(nn.Module):
         is_peft_model = False
         current_device = cls._get_current_device()
         if isinstance(pretrained_model_name_or_path, str):
-            is_loaded_in_8bit = pretrained_kwargs.pop("load_in_8bit", False)
+            is_loaded_in_8bit = pretrained_kwargs["load_in_8bit"] if "load_in_8bit" in pretrained_kwargs else False
         else:
             is_loaded_in_8bit = getattr(pretrained_model_name_or_path, "is_loaded_in_8bit", False)
 

--- a/trl/models/modeling_value_head.py
+++ b/trl/models/modeling_value_head.py
@@ -101,7 +101,7 @@ class AutoModelForCausalLMWithValueHead(PreTrainedModelWrapper):
                 Additional keyword arguments, that are passed to the `ValueHead` class.
         """
         super().__init__(pretrained_model)
-        v_head_kwargs, _ = self._split_kwargs(kwargs)
+        v_head_kwargs, _, _ = self._split_kwargs(kwargs)
 
         if not any(hasattr(self.pretrained_model, attribute) for attribute in self.lm_head_namings):
             raise ValueError("The model does not have a language model head, please use a model that has one.")
@@ -279,7 +279,7 @@ class AutoModelForSeq2SeqLMWithValueHead(PreTrainedModelWrapper):
 
     def __init__(self, pretrained_model, **kwargs):
         super().__init__(pretrained_model)
-        v_head_kwargs, _ = self._split_kwargs(kwargs)
+        v_head_kwargs, _, _ = self._split_kwargs(kwargs)
         self.is_encoder_decoder = True
 
         if not self._has_lm_head():


### PR DESCRIPTION
This PR slightly refactors the way we use / load peft models

For now I think it is important to let users pass the `PeftConfig` to `from_pretrained` , as it is an essential component for create peft models

I also think that we should be able to pass `prepare_int8_training` kwargs directly to `from_pretrained` as well, since sometimes you need some tweaks to enable int8 training

This PR is also fully backward compatible with the previous API

cc @lvwerra 