### PR TITLE
Reduce memory consumption in batched_forward_pass

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -654,6 +654,8 @@ class PPOTrainer(BaseTrainer):
                 List of tensors containing the encoded queries, shape (`batch_size`, `query_length`)
             responses (`torch.LongTensor`):
                 List of tensors containing the encoded responses, shape (`batch_size`, `response_length`)
+            return_logits (`bool`, *optional*, defaults to `False`):
+                Whether to return all_logits. Set to `False` if logits are not needed to reduce memory consumption.
         Returns:
             (tuple):
                 - all_logprobs (`torch.FloatTensor`): Log probabilities of the responses,


### PR DESCRIPTION
This PR reduces memory consumption in `batched_forward_pass` of PPOTrainer, by avoiding the storage of logits when they are not necessary.

Before this PR, `batched_forward_pass` stored all of the model's `logits` all the time like other tensors such as `values` and `logprobs`. Here, `logits` tensors have a much larger size (batch_size * tokens * **vocabulary_size**) compared to `logprobs` and `values` tensors (batch_size × tokens), consuming a significant amount of cuda memory.

I have modified `batched_forward_pass` to avoid unnecessary storage of `logits`, which is only required when calculating entropy in the `loss` method.