### PR TITLE
Adds checkpointing saving and loading

### DIFF
--- a/examples/sentiment/scripts/gpt2-sentiment.py
+++ b/examples/sentiment/scripts/gpt2-sentiment.py
@@ -77,8 +77,8 @@ config = PPOConfig(
     mini_batch_size=script_args.mini_batch_size,
     batch_size=script_args.batch_size,
     gradient_accumulation_steps=script_args.gradient_accumulation_steps,
-    output_dir="checkpoints",
-    load_step=0,
+    output_dir="run01",
+    resume_from_checkpoint=True,
     save_steps=10,
 )
 
@@ -168,7 +168,7 @@ output_min_length = 4
 output_max_length = 16
 output_length_sampler = LengthSampler(output_min_length, output_max_length)
 
-for epoch, batch in tqdm(enumerate(ppo_trainer.dataloader)):
+for epoch, batch in tqdm(enumerate(ppo_trainer.dataloader), initial=ppo_trainer.current_step):
     query_tensors = batch["input_ids"]
 
     # Get response from gpt2

--- a/examples/sentiment/scripts/gpt2-sentiment.py
+++ b/examples/sentiment/scripts/gpt2-sentiment.py
@@ -77,6 +77,9 @@ config = PPOConfig(
     mini_batch_size=script_args.mini_batch_size,
     batch_size=script_args.batch_size,
     gradient_accumulation_steps=script_args.gradient_accumulation_steps,
+    output_dir="checkpoints",
+    load_step=0,
+    save_steps=10,
 )
 
 

--- a/trl/models/modeling_value_head.py
+++ b/trl/models/modeling_value_head.py
@@ -200,15 +200,15 @@ class AutoModelForCausalLMWithValueHead(PreTrainedModelWrapper):
         to the state dictionary of the wrapped model by prepending the key with `v_head.`.
         """
         if not self.is_peft_model:
-            pretrained_model_state_dict = self.pretrained_model.state_dict(*args, **kwargs)
-        else:
-            # if it is a peft model, only save the v_head
-            pretrained_model_state_dict = {}
+            return super(PreTrainedModelWrapper, self).state_dict(*args, **kwargs)
+
+        # if it is a peft model, only save the v_head
+        model_state_dict = {}
 
         v_head_state_dict = self.v_head.state_dict(*args, **kwargs)
         for k, v in v_head_state_dict.items():
-            pretrained_model_state_dict[f"v_head.{k}"] = v
-        return pretrained_model_state_dict
+            model_state_dict[f"v_head.{k}"] = v
+        return model_state_dict
 
     def push_to_hub(self, *args, **kwargs):
         setattr(self.pretrained_model, "v_head", self.v_head)

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -77,6 +77,7 @@ class PPOConfig(object):
             Seed value for random generations
         optimize_cuda_cache (`bool`, *optional*, defaults to `False`):
             Optimize CUDA cache for slightly more memory-effcient training
+
     """
 
     def __init__(
@@ -106,6 +107,9 @@ class PPOConfig(object):
         max_grad_norm: Optional[float] = None,
         seed: Optional[int] = 0,
         optimize_cuda_cache: Optional[bool] = False,
+        output_dir: Optional[str] = None,
+        save_steps: Optional[int] = None,
+        load_step: Optional[int] = None,
     ):
         self.model_name = model_name
         self.steps = steps
@@ -147,6 +151,9 @@ class PPOConfig(object):
         self.accelerator_kwargs = accelerator_kwargs
         self.tracker_project_name = tracker_project_name
         self.optimize_cuda_cache = optimize_cuda_cache
+        self.output_dir = output_dir
+        self.save_steps = save_steps
+        self.load_step = load_step
         self.max_grad_norm = max_grad_norm
 
         self.total_ppo_epochs = int(np.ceil(steps / batch_size))

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -155,7 +155,7 @@ class PPOConfig(object):
         self.save_steps = save_steps
 
         self.resume_from_checkpoint = resume_from_checkpoint
-        if self.resume_from_checkpoint == False:
+        if self.resume_from_checkpoint is False:
             self.resume_from_checkpoint = None
         self.max_grad_norm = max_grad_norm
 

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import warnings
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 
@@ -109,7 +109,7 @@ class PPOConfig(object):
         optimize_cuda_cache: Optional[bool] = False,
         output_dir: Optional[str] = None,
         save_steps: Optional[int] = None,
-        load_step: Optional[int] = None,
+        resume_from_checkpoint: Optional[Union[str, bool]] = None,
     ):
         self.model_name = model_name
         self.steps = steps
@@ -153,7 +153,10 @@ class PPOConfig(object):
         self.optimize_cuda_cache = optimize_cuda_cache
         self.output_dir = output_dir
         self.save_steps = save_steps
-        self.load_step = load_step
+
+        self.resume_from_checkpoint = resume_from_checkpoint
+        if self.resume_from_checkpoint == False:
+            self.resume_from_checkpoint = None
         self.max_grad_norm = max_grad_norm
 
         self.total_ppo_epochs = int(np.ceil(steps / batch_size))

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 import inspect
 import os
-import re
-from pathlib import Path
 import time
 import warnings
+from pathlib import Path
 from typing import List, Optional, Union
 
 import datasets
@@ -28,8 +27,6 @@ from huggingface_hub import whoami
 from packaging import version
 from torch.optim import Adam
 from transformers import DataCollatorForLanguageModeling, PreTrainedTokenizer, PreTrainedTokenizerFast
-
-from .utils import get_last_checkpoint
 
 from ..core import (
     WANDB_PADDING,
@@ -49,6 +46,7 @@ from ..core import (
 from ..import_utils import is_torch_greater_2_0
 from ..models import SUPPORTED_ARCHITECTURES, PreTrainedModelWrapper, create_reference_model
 from . import AdaptiveKLController, BaseTrainer, FixedKLController, PPOConfig
+from .utils import get_last_checkpoint
 
 
 MODEL_CARD_TEMPLATE = """---
@@ -874,7 +872,9 @@ class PPOTrainer(BaseTrainer):
         advantages = masked_whiten(advantages, mask)
         advantages = advantages.detach()
 
-        vpredclipped = clip_by_value(vpreds, values - self.config.cliprange_value, values + self.config.cliprange_value)
+        vpredclipped = clip_by_value(
+            vpreds, values - self.config.cliprange_value, values + self.config.cliprange_value
+        )
 
         vf_losses1 = (vpreds - returns) ** 2
         vf_losses2 = (vpredclipped - returns) ** 2

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import re
 import numpy as np
 
 
@@ -40,3 +42,19 @@ class FixedKLController:
 
     def update(self, current, n_steps):
         pass
+
+
+PREFIX_CHECKPOINT_DIR = "checkpoint"
+_re_checkpoint = re.compile(r"^" + PREFIX_CHECKPOINT_DIR + r"_(\d+)$")
+
+
+def get_last_checkpoint(folder):
+    content = os.listdir(folder)
+    checkpoints = [
+        path
+        for path in content
+        if _re_checkpoint.search(path) is not None and os.path.isdir(os.path.join(folder, path))
+    ]
+    if len(checkpoints) == 0:
+        return
+    return os.path.join(folder, max(checkpoints, key=lambda x: int(_re_checkpoint.search(x).groups()[0])))

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import re
+
 import numpy as np
 
 


### PR DESCRIPTION
This PR adds the saving and loading of the model, optimizer and scheduler states.
I don't think it is really needed to store the ref model weights, but it was not clear how to get accelerate.save_state to ignore this.

I updated the example gpt2-sentiment to demonstrate the usage, we will probably want to revert these changes before merging.
I have not tested with a peft model yet.

Early feedback would be great @younesbelkada 
