### PR TITLE
adds early stopping

### DIFF
--- a/examples/sentiment/scripts/gpt2-sentiment.py
+++ b/examples/sentiment/scripts/gpt2-sentiment.py
@@ -66,7 +66,7 @@ class ScriptArguments:
         default=1, metadata={"help": "the number of gradient accumulation steps"}
     )
     early_stopping: Optional[bool] = field(default=False, metadata={"help": "whether to early stop"})
-    target_kl: Optional[float] = field(default=0.01, metadata={"help": "kl target for early stopping"})
+    target_kl: Optional[float] = field(default=0.1, metadata={"help": "kl target for early stopping"})
 
 
 parser = HfArgumentParser(ScriptArguments)

--- a/examples/sentiment/scripts/gpt2-sentiment.py
+++ b/examples/sentiment/scripts/gpt2-sentiment.py
@@ -65,6 +65,8 @@ class ScriptArguments:
     gradient_accumulation_steps: Optional[int] = field(
         default=1, metadata={"help": "the number of gradient accumulation steps"}
     )
+    early_stopping: Optional[bool] = field(default=False, metadata={"help": "whether to early stop"})
+    target_kl: Optional[float] = field(default=0.01, metadata={"help": "kl target for early stopping"})
 
 
 parser = HfArgumentParser(ScriptArguments)
@@ -77,6 +79,8 @@ config = PPOConfig(
     mini_batch_size=script_args.mini_batch_size,
     batch_size=script_args.batch_size,
     gradient_accumulation_steps=script_args.gradient_accumulation_steps,
+    early_stopping=script_args.early_stopping,
+    target_kl=script_args.target_kl,
 )
 
 

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -77,6 +77,10 @@ class PPOConfig(object):
             Seed value for random generations
         optimize_cuda_cache (`bool`, *optional*, defaults to `False`):
             Optimize CUDA cache for slightly more memory-effcient training
+        early_stopping (`bool`, *optional*, defaults to `False`):
+            Whether to stop the PPO opimization loop early is the KL too high
+        target_kl (`float`, *optional*, defaults to `0.01`):
+            Stop early if we exceed this value by over 50%
     """
 
     def __init__(
@@ -106,6 +110,8 @@ class PPOConfig(object):
         max_grad_norm: Optional[float] = None,
         seed: Optional[int] = 0,
         optimize_cuda_cache: Optional[bool] = False,
+        early_stopping: Optional[bool] = False,
+        target_kl: Optional[float] = 0.1,
     ):
         self.model_name = model_name
         self.steps = steps
@@ -148,6 +154,8 @@ class PPOConfig(object):
         self.tracker_project_name = tracker_project_name
         self.optimize_cuda_cache = optimize_cuda_cache
         self.max_grad_norm = max_grad_norm
+        self.early_stopping = early_stopping
+        self.target_kl = target_kl
 
         self.total_ppo_epochs = int(np.ceil(steps / batch_size))
 

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -79,7 +79,7 @@ class PPOConfig(object):
             Optimize CUDA cache for slightly more memory-effcient training
         early_stopping (`bool`, *optional*, defaults to `False`):
             Whether to stop the PPO opimization loop early is the KL too high
-        target_kl (`float`, *optional*, defaults to `0.01`):
+        target_kl (`float`, *optional*, defaults to `0.1`):
             Stop early if we exceed this value by over 50%
     """
 

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -924,7 +924,9 @@ class PPOTrainer(BaseTrainer):
         advantages = masked_whiten(advantages, mask)
         advantages = advantages.detach()
 
-        vpredclipped = clip_by_value(vpreds, values - self.config.cliprange_value, values + self.config.cliprange_value)
+        vpredclipped = clip_by_value(
+            vpreds, values - self.config.cliprange_value, values + self.config.cliprange_value
+        )
 
         vf_losses1 = (vpreds - returns) ** 2
         vf_losses2 = (vpredclipped - returns) ** 2

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -627,6 +627,7 @@ class PPOTrainer(BaseTrainer):
                 )
                 if self.config.early_stopping and train_stats["policy/policykl"] > 1.5 * self.config.target_kl:
                     early_stop = True
+                    self.optimizer.zero_grad()
                     break
 
                 all_stats.append(train_stats)


### PR DESCRIPTION
Adds early stopping to the PPO loop. Fixes #232 

I used a value of 0.1 as the threshold as I observed an initial spike of 0.2 before we had instabilities in gpt2-xl earlier this week:
![image](https://user-images.githubusercontent.com/7275864/226648055-8f0fa2f4-9a5d-4595-8718-f49e1615239d.png)

Note that RL4LM [use a value of 0.5 ](https://github.com/allenai/RL4LMs/blob/main/scripts/training/task_configs/dialog/gpt2_ppo.yml)

My only other concern is gradient accumulation. I think it would it be better to zero the gradients as soon as we see a splike in KL, or to leave them in the as is. I have zeroed them for now, but it would be great to have feedback on this.