### PR TITLE
[`core`] Add warning when negative KL

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -940,14 +940,6 @@ class PPOTrainer(BaseTrainer):
         return_mean, return_var = masked_mean(returns, mask), masked_var(returns, mask)
         value_mean, value_var = masked_mean(values, mask), masked_var(values, mask)
 
-        if policykl.item() < 0.0:
-            # warn users
-            warnings.warn(
-                f"KL divergence is starting to become negative: {policykl.item()} - this might be a precursor for failed training."
-                " sometimes this happens because the generation kwargs are not correctly set. Please make sure"
-                " that the generation kwargs are set correctly, or review your training hyperparameters."
-            )
-
         stats = dict(
             loss=dict(policy=pg_loss.detach(), value=vf_loss.detach(), total=loss.detach()),
             policy=dict(
@@ -992,6 +984,14 @@ class PPOTrainer(BaseTrainer):
         mean_entropy = (-data["logprobs"] * mask).sum(axis=-1).mean()
 
         mean_non_score_reward = masked_mean(data["non_score_reward"], mask)
+
+        if mean_kl.item() < 0.0:
+            # warn users
+            warnings.warn(
+                f"KL divergence is starting to become negative: {mean_kl.item()} - this might be a precursor for failed training."
+                " sometimes this happens because the generation kwargs are not correctly set. Please make sure"
+                " that the generation kwargs are set correctly, or review your training hyperparameters."
+            )
 
         stats = {
             "objective/kl": mean_kl,

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -988,7 +988,7 @@ class PPOTrainer(BaseTrainer):
         if mean_kl.item() < 0.0:
             # warn users
             warnings.warn(
-                f"KL divergence is starting to become negative: {mean_kl.item()} - this might be a precursor for failed training."
+                f"KL divergence is starting to become negative: {mean_kl.item():.2f} - this might be a precursor for failed training."
                 " sometimes this happens because the generation kwargs are not correctly set. Please make sure"
                 " that the generation kwargs are set correctly, or review your training hyperparameters."
             )

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -750,7 +750,6 @@ class PPOTrainer(BaseTrainer):
             input_kwargs = {key: value[i * fbs : (i + 1) * fbs] for key, value in model_inputs.items()}
             query_batch = queries[i * fbs : (i + 1) * fbs]
             response_batch = responses[i * fbs : (i + 1) * fbs]
-
             logits, _, values = model(**input_kwargs)
 
             if self.is_encoder_decoder:


### PR DESCRIPTION
# What does this PR do?

Fixes: #235 

The warning message will be displayed only once, if there is a repetition, as described in the official documentation of `warnings` package: https://docs.python.org/2/library/warnings.html / https://stackoverflow.com/questions/22661745/why-only-one-warning-in-a-loop

cc @lvwerra 