### PR TITLE
[`distributed`] Fix early stopping and DP

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -642,7 +642,7 @@ class PPOTrainer(BaseTrainer):
                         dist.all_reduce(policykl, dist.ReduceOp.SUM)
                         policykl /= self.accelerator.num_processes
 
-                        if policykl > 0 * self.config.target_kl:
+                        if policykl > 1.5 * self.config.target_kl:
                             early_stop = True
                             self.optimizer.zero_grad()
                             break

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -625,11 +625,14 @@ class PPOTrainer(BaseTrainer):
                     vpreds,
                     batch["masks"],
                 )
+
+                all_stats.append(train_stats)
+
                 if self.config.early_stopping:
                     policykl = train_stats["policy/policykl"]
                     early_stop = self._early_stop(policykl)
-
-                all_stats.append(train_stats)
+                    if early_stop:
+                        break
 
         timing["time/ppo/optimize_step"] = time.time() - t
 

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -703,7 +703,7 @@ class PPOTrainer(BaseTrainer):
             dist.all_reduce(policykl, dist.ReduceOp.SUM)
             policykl /= self.accelerator.num_processes
 
-            if policykl > 0 * self.config.target_kl:
+            if policykl > 1.5 * self.config.target_kl:
                 self.optimizer.zero_grad()
                 early_stop = True
         return early_stop

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -627,25 +627,7 @@ class PPOTrainer(BaseTrainer):
                 )
                 if self.config.early_stopping:
                     policykl = train_stats["policy/policykl"]
-
-                    if not self.is_distributed and policykl > 1.5 * self.config.target_kl:
-                        early_stop = True
-                        self.optimizer.zero_grad()
-                        break
-                    elif self.is_distributed:
-                        import torch.distributed as dist
-
-                        # Wait for all processes to finish
-                        dist.barrier()
-
-                        # all gather the policykl
-                        dist.all_reduce(policykl, dist.ReduceOp.SUM)
-                        policykl /= self.accelerator.num_processes
-
-                        if policykl > 1.5 * self.config.target_kl:
-                            early_stop = True
-                            self.optimizer.zero_grad()
-                            break
+                    early_stop = self._early_stop(policykl)
 
                 all_stats.append(train_stats)
 
@@ -690,6 +672,41 @@ class PPOTrainer(BaseTrainer):
             self.lr_scheduler.step()
 
         return stats
+
+    def _early_stop(self, policykl):
+        r"""
+        Handles the early stopping logic. If the policy KL is greater than the target KL, then the gradient is zeroed and
+        the optimization step is skipped.
+        This also handles the multi-gpu case where the policy KL is averaged across all processes.
+
+        Args:
+            policy_kl (torch.Tensor):
+                the policy KL
+
+        Returns:
+            `bool`: whether to early stop or not
+        """
+        early_stop = False
+        if not self.config.early_stopping:
+            return early_stop
+
+        if not self.is_distributed and policykl > 1.5 * self.config.target_kl:
+            self.optimizer.zero_grad()
+            early_stop = True
+        elif self.is_distributed:
+            import torch.distributed as dist
+
+            # Wait for all processes to finish
+            dist.barrier()
+
+            # all gather the policykl
+            dist.all_reduce(policykl, dist.ReduceOp.SUM)
+            policykl /= self.accelerator.num_processes
+
+            if policykl > 0 * self.config.target_kl:
+                self.optimizer.zero_grad()
+                early_stop = True
+        return early_stop
 
     def gather_stats(self, stats):
         """


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue where the training was hanging in multi-GPU setting and using earyl stopping
In fact, in a multi-GPU setting, we need to compute the average of `policykl` across all GPUs, and call early stopping

I can confirm this solution worked, the way I checked was to add a print after the `self.optimizer_zero_grad` and forcing the coefficient to be `0` :
`if policykl > 0 * self.config.target_kl:`

cc @edbeeching @lvwerra 

```bash
4it [00:03,  1.36it/s]early stopping successfulearly stopping successful
5it [00:04,  1.21it/s]early stopping successful
```