### PR TITLE
Add LlaMa in tests + `create_reference_model`

### DIFF
--- a/tests/test_modeling_value_head.py
+++ b/tests/test_modeling_value_head.py
@@ -30,6 +30,7 @@ ALL_CAUSAL_LM_MODELS = [
     "trl-internal-testing/tiny-random-BloomForCausalLM",
     "trl-internal-testing/tiny-random-GPT2LMHeadModel",
     "trl-internal-testing/tiny-random-CodeGenForCausalLM-sharded",
+    "trl-internal-testing/tiny-random-LlamaForCausalLM",
 ]
 
 ALL_SEQ2SEQ_MODELS = [

--- a/tests/test_modeling_value_head.py
+++ b/tests/test_modeling_value_head.py
@@ -30,7 +30,7 @@ ALL_CAUSAL_LM_MODELS = [
     "trl-internal-testing/tiny-random-BloomForCausalLM",
     "trl-internal-testing/tiny-random-GPT2LMHeadModel",
     "trl-internal-testing/tiny-random-CodeGenForCausalLM-sharded",
-    "trl-internal-testing/tiny-random-LlamaForCausalLM",
+    # "trl-internal-testing/tiny-random-LlamaForCausalLM", uncomment on the next transformers release
 ]
 
 ALL_SEQ2SEQ_MODELS = [

--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -36,7 +36,12 @@ if is_peft_available():
     )
 
 
-LAYER_PATTERNS = ["transformer.h.{layer}", "model.decoder.layers.{layer}", "gpt_neox.layers.{layer}"]
+LAYER_PATTERNS = [
+    "transformer.h.{layer}",
+    "model.decoder.layers.{layer}",
+    "gpt_neox.layers.{layer}",
+    "model.layers.{layer}",
+]
 
 
 class PreTrainedModelWrapper(nn.Module):

--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -418,4 +418,7 @@ def create_reference_model(
         param = ref_model.get_parameter(param_name)
         param.requires_grad = False
 
+    if pattern is not None and len(unshared_param_list) == 0:
+        logging.warning("Pattern passed or found, but no layers matched in the model. Check for a typo.")
+
     return ref_model.eval()


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/lvwerra/trl/issues/258
Before this PR, Llama was not supported by `create_reference_model`, hence users needed to manually define the pattern of the layers to properly create a reference model, and this can be error prone.

This PR simply adds the Llama layer pattern for `create_reference_model`, I also added a tiny Llama model for testing purpose

cc @lvwerra 