### PR TITLE
[`t5`] Fix negative kl issue

### DIFF
--- a/examples/sentiment/scripts/t5-sentiment.py
+++ b/examples/sentiment/scripts/t5-sentiment.py
@@ -120,7 +120,8 @@ dataset = build_imdb_dataset(tokenizer)
 
 query = tokenizer("I really liked this movie because", return_tensors="pt")["input_ids"]
 
-generation_kwargs = {"top_k": 0.0, "top_p": 1.0, "do_sample": True, "eos_token_id": -1}
+# generation_kwargs = {"top_k": 0.0, "top_p": 1.0, "do_sample": True, "eos_token_id": -1}
+generation_kwargs = {"top_k": 0.0, "top_p": 1.0, "do_sample": True}
 
 
 # We then build the PPOTrainer, passing the model, the reference model, the tokenizer
@@ -148,8 +149,7 @@ for epoch, batch in tqdm(enumerate(ppo_trainer.dataloader)):
     response_tensors = ppo_trainer.generate(
         query_tensors, return_prompt=False, length_sampler=output_length_sampler, **generation_kwargs
     )
-    response_tensors = [r[1:] for r in response_tensors]
-    batch["response"] = tokenizer.batch_decode(response_tensors)
+    batch["response"] = tokenizer.batch_decode([r[1:] for r in response_tensors])
 
     # Compute sentiment score
     texts = [q + r for q, r in zip(batch["query"], batch["response"])]

--- a/examples/sentiment/scripts/t5-sentiment.py
+++ b/examples/sentiment/scripts/t5-sentiment.py
@@ -120,8 +120,7 @@ dataset = build_imdb_dataset(tokenizer)
 
 query = tokenizer("I really liked this movie because", return_tensors="pt")["input_ids"]
 
-# generation_kwargs = {"top_k": 0.0, "top_p": 1.0, "do_sample": True, "eos_token_id": -1}
-generation_kwargs = {"top_k": 0.0, "top_p": 1.0, "do_sample": True}
+generation_kwargs = {"top_k": 0.0, "top_p": 1.0, "do_sample": True, "eos_token_id": -1}
 
 
 # We then build the PPOTrainer, passing the model, the reference model, the tokenizer

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -417,7 +417,8 @@ class PPOTrainer(BaseTrainer):
         outputs = []
 
         padding_side_default = self.tokenizer.padding_side
-        self.tokenizer.padding_side = "left"
+        if not self.is_encoder_decoder:
+            self.tokenizer.padding_side = "left"
 
         # in case we have fewer examples than bs
         batch_size = min(len(query_tensors), batch_size)
@@ -444,7 +445,12 @@ class PPOTrainer(BaseTrainer):
             generations = self.accelerator.unwrap_model(self.model).generate(**padded_inputs, **generation_kwargs)
 
             for generation, mask in zip(generations, padded_inputs["attention_mask"]):
-                output = generation[(1 - mask).sum() :]  # remove padding
+                if not self.is_encoder_decoder:
+                    output = generation[(1 - mask).sum() :]  # remove padding
+                else:
+                    output = generation
+
+
                 if not return_prompt and not self.is_encoder_decoder:
                     output = output[(mask).sum() :]  # remove prompt
                 outputs.append(output)

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -450,7 +450,6 @@ class PPOTrainer(BaseTrainer):
                 else:
                     output = generation
 
-
                 if not return_prompt and not self.is_encoder_decoder:
                     output = output[(mask).sum() :]  # remove prompt
                 outputs.append(output)


### PR DESCRIPTION
Fixes #256 

This PR fixes issues related with negative KL and T5 sentiment example. The first fix was related to the sentiment script that was incorrectly ported.

Before this PR, the padding side of tokenizers was always hardcoded to `left` in `_batched_generate`. in encoder-decoder models, they should be set to their native `padding_side` (i.e. `right` for T5), as the padding is performed on the encoder tokens, and these models have been trained with this specific padding side. I think that the culprit is the way the positional attention bias is computed, that does not take into account the starting position if `padding_side=left`: https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/modeling_t5.py#L436-L451 

Thus forcing padding_side=left for encoder-decoder models should probably be avoided, as most of Enc-dec models pad the encoder input to the right (to verify).

To illustrate the fix: 

- [run on `main` with the modification on the example script only](https://wandb.ai/distill-bloom/trl/runs/0extfcp0)
- [run on this branch](https://wandb.ai/distill-bloom/trl/runs/nxsxr2y3) 

You can see that using `padding_side=left` led to unstable KL, whereas the proposed fix seems to lead to smoother KL

![Screenshot 2023-03-29 at 17 16 25](https://user-images.githubusercontent.com/49240599/228586122-1ca375ee-5d0d-442b-8336-2a4b5120111b.png)

cc @lvwerra 