### PR TITLE
Use active model to generate response in example on README (#269)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ query_txt = "This morning I went to the "
 query_tensor = tokenizer.encode(query_txt, return_tensors="pt")
 
 # get model response
-response_tensor  = respond_to_batch(model_ref, query_tensor)
+response_tensor  = respond_to_batch(model, query_tensor)
 
 # create a ppo trainer
 ppo_trainer = PPOTrainer(ppo_config, model, model_ref, tokenizer)


### PR DESCRIPTION
This PR is a simple doc change to the example in the README. The active model is used to generate the response in place of the reference model. This change accurately reflects the workflow highlighted in the diagram before the example.

Addresses issue #269 