### PR TITLE
[`core`] Officially Support Reward Modeling

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -15,6 +15,8 @@
     title: Model Classes
   - local: trainer
     title: Trainer Classes
+  - local: Reward Modeling
+    title: Training your own reward model
   title: API
 - sections: 
   - local: sentiment_tuning

--- a/docs/source/trainer.mdx
+++ b/docs/source/trainer.mdx
@@ -2,6 +2,7 @@
 
 At TRL we support PPO (Proximal Policy Optimisation) with an implementation that largely follows  the structure introduced in the paper "Fine-Tuning Language Models from Human Preferences" by D. Ziegler et al. [[paper](https://arxiv.org/pdf/1909.08593.pdf), [code](https://github.com/openai/lm-human-preferences)].
 The Trainer and model classes are largely inspired from `transformers.Trainer` and `transformers.AutoModel` classes and adapted for RL.
+We also support a RewardTrainer that can be used to train a reward model.
 
 ## PPOConfig
 
@@ -10,6 +11,10 @@ The Trainer and model classes are largely inspired from `transformers.Trainer` a
 ## PPOTrainer
 
 [[autodoc]] PPOTrainer
+
+## RewardTrainer
+
+[[autodoc]] RewardTrainer
 
 ## set_seed
 

--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -1,0 +1,234 @@
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tempfile
+import unittest
+
+import torch
+from datasets import Dataset
+from transformers import AutoModelForSequenceClassification, AutoTokenizer, TrainingArguments
+
+from trl import RewardTrainer
+
+from .testing_utils import require_peft
+
+
+class RewardTrainerTester(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model_id = "trl-internal-testing/dummy-GPT2-correct-vocab"
+        cls.model = AutoModelForSequenceClassification.from_pretrained(cls.model_id)
+        cls.tokenizer = AutoTokenizer.from_pretrained(cls.model_id)
+        cls.tokenizer.pad_token = cls.tokenizer.eos_token
+
+    def test_reward_trainer(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            training_args = TrainingArguments(
+                output_dir=tmp_dir,
+                per_device_train_batch_size=2,
+                max_steps=1,
+                remove_unused_columns=False,
+            )
+
+            # fmt: off
+            # noqa
+            dummy_dataset_dict = {
+                "input_ids_j": [
+                    torch.LongTensor([0, 1, 2,]),
+                    torch.LongTensor([1, 2]),
+                    torch.LongTensor([0, 1, 2,]),
+                    torch.LongTensor([1, 2]),
+                ],
+                "attention_mask_j": [
+                    torch.LongTensor([1, 1, 1]),
+                    torch.LongTensor([1, 0]),
+                    torch.LongTensor([1, 1, 1]),
+                    torch.LongTensor([1, 0]),
+                ],
+                "input_ids_k": [
+                    torch.LongTensor([0, 2,]),
+                    torch.LongTensor([1, 2, 0]),
+                    torch.LongTensor([0, 2,]),
+                    torch.LongTensor([1, 2, 0]),
+                ],
+                "attention_mask_k": [
+                    torch.LongTensor([1, 1]),
+                    torch.LongTensor([1, 1, 0]),
+                    torch.LongTensor([1, 1]),
+                    torch.LongTensor([1, 1, 1]),
+                ],
+            }
+            # fmt: on
+            dummy_dataset = Dataset.from_dict(dummy_dataset_dict)
+
+            trainer = RewardTrainer(
+                model=self.model,
+                args=training_args,
+                use_reward_data_collator=True,
+                tokenizer=self.tokenizer,
+                train_dataset=dummy_dataset,
+                max_length=512,
+            )
+
+            trainer.train()
+
+            self.assertIsNotNone(trainer.state.log_history[0]["train_loss"])
+
+            # check gradients are not None
+            for param in trainer.model.parameters():
+                self.assertIsNotNone(param.grad)
+
+    @require_peft
+    def test_reward_trainer_peft(self):
+        import peft
+        from peft import LoraConfig, TaskType
+
+        peft_version = peft.__version__
+
+        peft_config = LoraConfig(
+            task_type=TaskType.SEQ_CLS,
+            inference_mode=False,
+            r=8,
+            lora_alpha=32,
+            lora_dropout=0.1,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            training_args = TrainingArguments(
+                output_dir=tmp_dir,
+                per_device_train_batch_size=2,
+                max_steps=1,
+                remove_unused_columns=False,
+            )
+
+            # fmt: off
+            dummy_dataset_dict = {
+                "input_ids_j": [
+                    torch.LongTensor([0, 1, 2,]),
+                    torch.LongTensor([1, 2]),
+                    torch.LongTensor([0, 1, 2,]),
+                    torch.LongTensor([1, 2]),
+                ],
+                "attention_mask_j": [
+                    torch.LongTensor([1, 1, 1]),
+                    torch.LongTensor([1, 0]),
+                    torch.LongTensor([1, 1, 1]),
+                    torch.LongTensor([1, 0]),
+                ],
+                "input_ids_k": [
+                    torch.LongTensor([0, 2,]),
+                    torch.LongTensor([1, 2, 0]),
+                    torch.LongTensor([0, 2,]),
+                    torch.LongTensor([1, 2, 0]),
+                ],
+                "attention_mask_k": [
+                    torch.LongTensor([1, 1]),
+                    torch.LongTensor([1, 1, 0]),
+                    torch.LongTensor([1, 1]),
+                    torch.LongTensor([1, 1, 1]),
+                ],
+            }
+            # fmt: on
+            dummy_dataset = Dataset.from_dict(dummy_dataset_dict)
+
+            trainer = RewardTrainer(
+                model=self.model,
+                args=training_args,
+                use_reward_data_collator=True,
+                tokenizer=self.tokenizer,
+                train_dataset=dummy_dataset,
+                max_length=512,
+                peft_config=peft_config,
+            )
+
+            trainer.train()
+
+            self.assertIsNotNone(trainer.state.log_history[0]["train_loss"])
+
+            # due to a change in the way the modules to save are dealt in PEFT.
+            trainable_params_name = ["lora", "score"] if peft_version < "0.3.0" else ["lora", "modules_to_save"]
+
+            # check gradients are not None
+            for n, param in trainer.model.named_parameters():
+                if any([t in n for t in trainable_params_name]):
+                    self.assertIsNotNone(param.grad)
+                else:
+                    self.assertIsNone(param.grad)
+
+    def test_reward_trainer_assert_value_error(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            training_args = TrainingArguments(
+                output_dir=tmp_dir,
+                per_device_train_batch_size=2,
+                max_steps=1,
+                remove_unused_columns=False,
+            )
+
+            dummy_dataset_dict = {
+                # fmt: off
+                "input_ids_b": [
+                    torch.LongTensor([0, 1, 2,]),
+                    torch.LongTensor([1, 2]),
+                    torch.LongTensor([0, 1, 2,]),
+                    torch.LongTensor([1, 2]),
+                ],
+                "attention_mask_c": [
+                    torch.LongTensor([1, 1, 1]),
+                    torch.LongTensor([1, 0]),
+                    torch.LongTensor([1, 1, 1]),
+                    torch.LongTensor([1, 0]),
+                ],
+                "input_ids_f": [
+                    torch.LongTensor([0, 2,]),
+                    torch.LongTensor([1, 2, 0]),
+                    torch.LongTensor([0, 2,]),
+                    torch.LongTensor([1, 2, 0]),
+                ],
+                "attention_mask_g": [
+                    torch.LongTensor([1, 1]),
+                    torch.LongTensor([1, 1, 0]),
+                    torch.LongTensor([1, 1]),
+                    torch.LongTensor([1, 1, 1]),
+                ],
+                # fmt: on
+            }
+            dummy_dataset = Dataset.from_dict(dummy_dataset_dict)
+
+            trainer = RewardTrainer(
+                model=self.model,
+                args=training_args,
+                use_reward_data_collator=True,
+                tokenizer=self.tokenizer,
+                train_dataset=dummy_dataset,
+                max_length=512,
+            )
+
+            with self.assertRaises(ValueError):
+                trainer.train()
+
+            training_args = TrainingArguments(
+                output_dir=tmp_dir,
+                per_device_train_batch_size=2,
+                max_steps=1,
+                remove_unused_columns=True,
+            )
+
+            with self.assertRaises(ValueError):
+                trainer = RewardTrainer(
+                    model=self.model,
+                    args=training_args,
+                    use_reward_data_collator=True,
+                    tokenizer=self.tokenizer,
+                    train_dataset=dummy_dataset,
+                    max_length=512,
+                )

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -10,4 +10,4 @@ from .models import (
     PreTrainedModelWrapper,
     create_reference_model,
 )
-from .trainer import PPOConfig, PPOTrainer
+from .trainer import PPOConfig, PPOTrainer, RewardTrainer

--- a/trl/trainer/__init__.py
+++ b/trl/trainer/__init__.py
@@ -23,3 +23,4 @@ from .utils import AdaptiveKLController, FixedKLController
 from .base import BaseTrainer
 from .ppo_config import PPOConfig
 from .ppo_trainer import PPOTrainer
+from .reward_trainer import RewardTrainer

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -1,0 +1,139 @@
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Callable, Dict, List, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+from datasets import Dataset
+from transformers import DataCollator, PreTrainedModel, PreTrainedTokenizerBase, Trainer, TrainingArguments
+from transformers.trainer_callback import TrainerCallback
+from transformers.trainer_utils import EvalPrediction
+
+from ..import_utils import is_peft_available
+from .utils import RewardDataCollatorWithPadding
+
+
+if is_peft_available():
+    from peft import get_peft_model
+
+
+class RewardTrainer(Trainer):
+    r"""
+    The RewardTrainer can be used to train your custom Reward Model. It is a subclass of the
+    `transformers.Trainer` class and inherits all of its attributes and methods. It is recommended to use
+    an `AutoModelForSequenceClassification` as the reward model. The reward model should be trained on a dataset
+    of paired examples, where each example is a tuple of two sequences. The reward model should be trained to
+    predict which example in the pair is more relevant to the task at hand.
+
+    """
+
+    def __init__(
+        self,
+        model: Union[PreTrainedModel, nn.Module] = None,
+        args: TrainingArguments = None,
+        data_collator: Optional[DataCollator] = None,
+        train_dataset: Optional[Dataset] = None,
+        eval_dataset: Optional[Union[Dataset, Dict[str, Dataset]]] = None,
+        tokenizer: Optional[PreTrainedTokenizerBase] = None,
+        model_init: Optional[Callable[[], PreTrainedModel]] = None,
+        compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
+        callbacks: Optional[List[TrainerCallback]] = None,
+        optimizers: Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR] = (None, None),
+        preprocess_logits_for_metrics: Optional[Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = None,
+        **kwargs,
+    ):
+        """
+        Initialize RewardTrainer.
+
+        Args:
+            model (`transformers.PreTrainedModel`):
+                The model to train, preferably an `AutoModelForSequenceClassification`.
+            args (`transformers.TrainingArguments`):
+                The arguments to use for training.
+            data_collator (`transformers.DataCollator`):
+                The data collator to use for training. If None is specified, the default data collator (`RewardDataCollatorWithPadding`) will be used
+                which will pad the sequences to the maximum length of the sequences in the batch, given a dataset of paired sequences.
+            train_dataset (`datasets.Dataset`):
+                The dataset to use for training.
+            eval_dataset (`datasets.Dataset`):
+                The dataset to use for evaluation.
+            tokenizer (`transformers.PreTrainedTokenizerBase`):
+                The tokenizer to use for training. This argument is required if you want to use the default data collator.
+            model_init (`Callable[[], transformers.PreTrainedModel]`):
+                The model initializer to use for training. If None is specified, the default model initializer will be used.
+            compute_metrics (`Callable[[transformers.EvalPrediction], Dict]`):
+                The metrics to use for evaluation.
+            callbacks (`List[transformers.TrainerCallback]`):
+                The callbacks to use for training.
+            optimizers (`Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR]`):
+                The optimizer and scheduler to use for training.
+            preprocess_logits_for_metrics (`Callable[[torch.Tensor, torch.Tensor], torch.Tensor]`):
+                The function to use to preprocess the logits before computing the metrics.
+            kwargs (`Dict`):
+                Additional keyword arguments to pass to the `RewardTrainer` class. The supported arguments are:
+                    - `use_reward_data_collator` (`bool`, defaults to `False`): Whether to use the default data collator (`RewardDataCollatorWithPadding`).
+                    - `max_length` (`int`, defaults to `None`): The maximum length of the sequences in the batch. This argument is required if you want to use the default data collator.
+                    - `peft_config` (`Dict`, defaults to `None`): The PEFT configuration to use for training. If you pass a PEFT configuration, the model will be wrapped in a PEFT model.
+        """
+        use_reward_data_collator = kwargs.pop("use_reward_data_collator", False)
+        max_length = kwargs.pop("max_length", None)
+        peft_config = kwargs.pop("peft_config", None)
+
+        if not is_peft_available() and peft_config is not None:
+            raise ValueError(
+                "PEFT is not installed and you passed a `peft_config` in the trainer's kwargs, please install it to use the PEFT models"
+            )
+        elif is_peft_available() and peft_config is not None:
+            model = get_peft_model(model, peft_config)
+
+        if use_reward_data_collator and data_collator is None:
+            if max_length is None or tokenizer is None:
+                raise ValueError(
+                    "max_length or a tokenizer must be specified when using the default RewardDataCollatorWithPadding"
+                )
+            data_collator = RewardDataCollatorWithPadding(tokenizer, max_length=max_length)
+
+            if args.remove_unused_columns:
+                # warn users that they should use `remove_unused_columns=False` when using RewardDataCollatorWithPadding
+                raise ValueError(
+                    "When using RewardDataCollatorWithPadding, you should set `remove_unused_columns=False` in your TrainingArguments"
+                )
+
+        self.use_reward_data_collator = use_reward_data_collator
+
+        super().__init__(
+            model,
+            args,
+            data_collator,
+            train_dataset,
+            eval_dataset,
+            tokenizer,
+            model_init,
+            compute_metrics,
+            callbacks,
+            optimizers,
+            preprocess_logits_for_metrics,
+        )
+
+    def compute_loss(self, model, inputs, return_outputs=False):
+        if not self.use_reward_data_collator:
+            raise NotImplementedError(
+                "compute_loss is only implemented for RewardDataCollatorWithPadding, please implement your own compute_loss method if you are using a custom data collator"
+            )
+        rewards_j = model(input_ids=inputs["input_ids_j"], attention_mask=inputs["attention_mask_j"])[0]
+        rewards_k = model(input_ids=inputs["input_ids_k"], attention_mask=inputs["attention_mask_k"])[0]
+        loss = -nn.functional.logsigmoid(rewards_j - rewards_k).mean()
+        if return_outputs:
+            return loss, {"rewards_j": rewards_j, "rewards_k": rewards_k}
+        return loss

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
+
 import numpy as np
+from transformers import PreTrainedTokenizerBase
 
 
 class AdaptiveKLController:
@@ -40,3 +44,76 @@ class FixedKLController:
 
     def update(self, current, n_steps):
         pass
+
+
+@dataclass
+class RewardDataCollatorWithPadding:
+    r"""
+    Reward DataCollator class that padds the inputs to the maximum length of the batch.
+    Args:
+        tokenizer (`PreTrainedTokenizerBase`):
+            The tokenizer used for encoding the data.
+        padding (`Union[bool, str, `PaddingStrategy`]`, `optional`, defaults to `True`):
+            padding_strategy to pass to the tokenizer.
+        max_length (`Optional[int]`, `optional`, defaults to `None`):
+            The maximum length of the sequence to be processed.
+        pad_to_multiple_of (`Optional[int]`, `optional`, defaults to `None`):
+            If set will pad the sequence to a multiple of the provided value.
+        return_tensors (`str`, `optional`, defaults to `"pt"`):
+            The tensor type to use.
+    """
+    tokenizer: PreTrainedTokenizerBase
+    padding: Union[bool, str] = True
+    max_length: Optional[int] = None
+    pad_to_multiple_of: Optional[int] = None
+    return_tensors: str = "pt"
+
+    def __call__(self, features: List[Dict[str, Any]]) -> Dict[str, Any]:
+        features_j = []
+        features_k = []
+        for feature in features:
+            # check if the keys are named as expected
+            if (
+                "input_ids_j" not in feature
+                or "input_ids_k" not in feature
+                or "attention_mask_j" not in feature
+                or "attention_mask_k" not in feature
+            ):
+                raise ValueError(
+                    "The features should include `input_ids_j`, `attention_mask_j`, `input_ids_k` and `attention_mask_k`"
+                )
+
+            features_j.append(
+                {
+                    "input_ids": feature["input_ids_j"],
+                    "attention_mask": feature["attention_mask_j"],
+                }
+            )
+            features_k.append(
+                {
+                    "input_ids": feature["input_ids_k"],
+                    "attention_mask": feature["attention_mask_k"],
+                }
+            )
+        batch_j = self.tokenizer.pad(
+            features_j,
+            padding=self.padding,
+            max_length=self.max_length,
+            pad_to_multiple_of=self.pad_to_multiple_of,
+            return_tensors=self.return_tensors,
+        )
+        batch_k = self.tokenizer.pad(
+            features_k,
+            padding=self.padding,
+            max_length=self.max_length,
+            pad_to_multiple_of=self.pad_to_multiple_of,
+            return_tensors=self.return_tensors,
+        )
+        batch = {
+            "input_ids_j": batch_j["input_ids"],
+            "attention_mask_j": batch_j["attention_mask"],
+            "input_ids_k": batch_k["input_ids"],
+            "attention_mask_k": batch_k["attention_mask"],
+            "return_loss": True,
+        }
+        return batch


### PR DESCRIPTION
# What does this PR do?

With Reward modeling being an important piece of PPO algorithm, it would be cool to support an "official" RewardTrainer in `trl`.

The `RewardTrainer` simply inherits from `transformers.Trainer`, but with some constraints. Users should be responsible to create a paired dataset that contains `input_ids_j`, `input_ids_k`, `attention_mask_j`, `attention_mask_k`, if they want to use the default `RewardDataCollatorWithPadding` data collator. 
Also I propose to add the possibility to create the PEFT model under the hood, if a user passes a `PeftConfig` to the Trainer. 

This PR adds a first version of it, adds also nice tests and cool documentation about that

cc @lvwerra 