### PR TITLE
Give a key to the wandb PPOConfig config entry

### DIFF
--- a/examples/sentiment/notebooks/gpt2-sentiment-control.ipynb
+++ b/examples/sentiment/notebooks/gpt2-sentiment-control.ipynb
@@ -721,7 +721,10 @@
    "source": [
     "for epoch in range(2):\n",
     "    for batch in tqdm(ppo_trainer.dataloader):\n",
-    "        logs, game_data, = (\n",
+    "        (\n",
+    "            logs,\n",
+    "            game_data,\n",
+    "        ) = (\n",
     "            dict(),\n",
     "            dict(),\n",
     "        )\n",

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -184,7 +184,8 @@ class PPOTrainer(BaseTrainer):
             **config.accelerator_kwargs,
         )
         self.accelerator.init_trackers(
-            config.tracker_project_name, config=config.to_dict(), init_kwargs=config.tracker_kwargs
+            config.tracker_project_name, config=dict(trl_ppo_trainer_config=config.to_dict()), 
+            init_kwargs=config.tracker_kwargs,
         )
 
         self.model = model

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -184,7 +184,8 @@ class PPOTrainer(BaseTrainer):
             **config.accelerator_kwargs,
         )
         self.accelerator.init_trackers(
-            config.tracker_project_name, config=dict(trl_ppo_trainer_config=config.to_dict()), 
+            config.tracker_project_name,
+            config=dict(trl_ppo_trainer_config=config.to_dict()),
             init_kwargs=config.tracker_kwargs,
         )
 


### PR DESCRIPTION
There is a lot of stuff with very generic keys in the `PPOConfig` dict, and the user may have logged a `wandb` config dict elsewhere. I know I had that problem. To counter that, I pass the PPOConfig dict in a dict under the key `trl_ppo_trainer_config`, to prevent collisions & be very clear.