### PR TITLE
[`CI`] Fix broken tests

### DIFF
--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -105,7 +105,6 @@ class PPOTrainerTester(unittest.TestCase):
         set_seed(42)
         cls._token = CI_HUB_USER_TOKEN
         cls._api = HfApi(endpoint=CI_HUB_ENDPOINT)
-        cls._api.set_access_token(CI_HUB_USER_TOKEN)
         HfFolder.save_token(CI_HUB_USER_TOKEN)
 
         # model_id


### PR DESCRIPTION
With the next release of `huggingface_hub`, the `set_access_token` method has been deprecated, see: https://github.com/huggingface/huggingface_hub/pull/1381

According to https://github.com/huggingface/transformers/pull/22051 - that function was used for code-legacy purposes and one shouldn't use `set_access_token` at the first place according to that PR. Therefore I propose to remove that line to unlock the failing CIs


cc @lvwerra 