### PR TITLE
Fix bug when loading local peft model

### DIFF
--- a/tests/test_peft_models.py
+++ b/tests/test_peft_models.py
@@ -163,3 +163,31 @@ class PeftModelTester(unittest.TestCase):
             # check all the weights are the same
             for p1, p2 in zip(model.named_parameters(), model_from_pretrained.named_parameters()):
                 self.assertTrue(torch.allclose(p1[1], p2[1]), msg=f"{p1[0]} != {p2[0]}")
+
+    def test_load_pretrained_peft(self):
+        r"""
+        Check that the model saved with peft class interface can be loaded properly.
+        """
+        causal_lm_model = AutoModelForCausalLM.from_pretrained(self.causal_lm_model_id)
+        pretrained_model = get_peft_model(causal_lm_model, self.lora_config)
+
+        model = AutoModelForCausalLMWithValueHead.from_pretrained(pretrained_model)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            pretrained_model.save_pretrained(tmp_dir)
+            model_from_pretrained = AutoModelForCausalLMWithValueHead.from_pretrained(tmp_dir)
+
+            # check that the files `adapter_model.bin` and `adapter_config.json` are in the directory
+            self.assertTrue(
+                os.path.isfile(f"{tmp_dir}/adapter_model.bin"),
+                msg=f"{tmp_dir}/adapter_model.bin does not exist",
+            )
+            self.assertTrue(
+                os.path.exists(f"{tmp_dir}/adapter_config.json"),
+                msg=f"{tmp_dir}/adapter_config.json does not exist",
+            )
+
+            # check all the weights are the same
+            for p1, p2 in zip(model.named_parameters(), model_from_pretrained.named_parameters()):
+                if p1[0] not in ["v_head.summary.weight", "v_head.summary.bias"]:
+                    self.assertTrue(torch.allclose(p1[1], p2[1]), msg=f"{p1[0]} != {p2[0]}")

--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -35,7 +35,6 @@ if is_peft_available():
         prepare_model_for_int8_training,
     )
 
-
 LAYER_PATTERNS = [
     "transformer.h.{layer}",
     "model.decoder.layers.{layer}",
@@ -164,8 +163,9 @@ class PreTrainedModelWrapper(nn.Module):
                     peft_config.base_model_name_or_path, *model_args, **pretrained_kwargs
                 )
 
-                pretrained_model = PeftModel.from_pretrained(pretrained_model, pretrained_model_name_or_path)
-                pretrained_model_name_or_path = pretrained_model # avoid enter resume_training branch in line 206
+                pretrained_model = PeftModel.from_pretrained(
+                    pretrained_model, pretrained_model_name_or_path, is_trainable=True
+                )
             else:
                 pretrained_model = cls.transformers_parent_class.from_pretrained(
                     pretrained_model_name_or_path, *model_args, **pretrained_kwargs
@@ -203,6 +203,7 @@ class PreTrainedModelWrapper(nn.Module):
 
         # if resume_training, load the state_dict again - this is ok since the
         # state_dict is removed from the model after loading it.
+        is_resuming_training = True
         if isinstance(pretrained_model_name_or_path, str):
             filename = os.path.join(pretrained_model_name_or_path, "pytorch_model.bin")
             sharded_index_filename = os.path.join(pretrained_model_name_or_path, "pytorch_model.bin.index.json")
@@ -216,27 +217,35 @@ class PreTrainedModelWrapper(nn.Module):
                     if os.path.exists(sharded_index_filename):
                         index_file_name = sharded_index_filename
                     else:
-                        index_file_name = hf_hub_download(
-                            pretrained_model_name_or_path, "pytorch_model.bin.index.json"
-                        )
+                        try:
+                            index_file_name = hf_hub_download(
+                                pretrained_model_name_or_path, "pytorch_model.bin.index.json"
+                            )
+                        except ValueError:  # not continue training, do not have v_head weight
+                            is_resuming_training = False
+                            logging.warning(
+                                f"A {type(pretrained_model)} model is loaded from '{pretrained_model_name_or_path}', "
+                                f"and no v_head weight is found. This IS expected if you are not resuming PPO training."
+                            )
                     # load json
-                    with open(index_file_name, "r") as f:
-                        index = json.load(f)
-                    # check filename with `v_head` or any known extra module:
-                    files_to_download = set()
-                    for k, v in index["weight_map"].items():
-                        if any([module in k for module in cls.supported_modules]):
-                            files_to_download.add(v)
-                    is_shared = True
-
-            if is_shared:
-                # download each file and add it to the state_dict
-                state_dict = {}
-                for shard_file in files_to_download:
-                    filename = hf_hub_download(pretrained_model_name_or_path, shard_file)
-                    state_dict.update(torch.load(filename, map_location="cpu"))
-            else:
-                state_dict = torch.load(filename, map_location="cpu")
+                    if is_resuming_training:
+                        with open(index_file_name, "r") as f:
+                            index = json.load(f)
+                        # check filename with `v_head` or any known extra module:
+                        files_to_download = set()
+                        for k, v in index["weight_map"].items():
+                            if any([module in k for module in cls.supported_modules]):
+                                files_to_download.add(v)
+                        is_shared = True
+            if is_resuming_training:
+                if is_shared:
+                    # download each file and add it to the state_dict
+                    state_dict = {}
+                    for shard_file in files_to_download:
+                        filename = hf_hub_download(pretrained_model_name_or_path, shard_file)
+                        state_dict.update(torch.load(filename, map_location="cpu"))
+                else:
+                    state_dict = torch.load(filename, map_location="cpu")
 
         else:
             state_dict = pretrained_model_name_or_path.state_dict()
@@ -244,7 +253,8 @@ class PreTrainedModelWrapper(nn.Module):
         model.is_peft_model = is_peft_model
         model.current_device = current_device
 
-        model.post_init(state_dict=state_dict)
+        if is_resuming_training:
+            model.post_init(state_dict=state_dict)
 
         return model
 

--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -163,9 +163,7 @@ class PreTrainedModelWrapper(nn.Module):
                     peft_config.base_model_name_or_path, *model_args, **pretrained_kwargs
                 )
 
-                pretrained_model = PeftModel.from_pretrained(
-                    pretrained_model, pretrained_model_name_or_path, is_trainable=True
-                )
+                pretrained_model = PeftModel.from_pretrained(pretrained_model, pretrained_model_name_or_path)
             else:
                 pretrained_model = cls.transformers_parent_class.from_pretrained(
                     pretrained_model_name_or_path, *model_args, **pretrained_kwargs

--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -165,6 +165,7 @@ class PreTrainedModelWrapper(nn.Module):
                 )
 
                 pretrained_model = PeftModel.from_pretrained(pretrained_model, pretrained_model_name_or_path)
+                pretrained_model_name_or_path = pretrained_model # avoid enter resume_training branch in line 206
             else:
                 pretrained_model = cls.transformers_parent_class.from_pretrained(
                     pretrained_model_name_or_path, *model_args, **pretrained_kwargs


### PR DESCRIPTION
Fix the bug in https://github.com/lvwerra/trl/issues/341.

When the local model weight and the lora weight are saved in different locations, the code will try `hf_hub_download` and throw `HFValidationError: Repo id must be in the form 'repo_name'` error twice. In the first time, the error was caught. But the second error will terminate the code.

After loading the local peft model, we can update `pretrained_model_name_or_path` to `pretrained_model` to avoid entering the resume_training branch. 