### PR TITLE
[`PPO`] Relax negative KL constraint

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -1083,7 +1083,7 @@ class PPOTrainer(BaseTrainer):
         mean_scores = torch.stack(data["scores"]).mean()  # scores is size `batch_size`
         std_scores = torch.stack(data["scores"]).std()
 
-        if mean_kl.item() < 0.0:
+        if mean_kl.item() < -1.0:
             # warn users
             warnings.warn(
                 f"KL divergence is starting to become negative: {mean_kl.item():.2f} - this might be a precursor for failed training."


### PR DESCRIPTION
# What does this PR do?

This PR should relac the negative KL warning, in fact having a KL that is between [0; -1] shouldn't be super bad, hence we should warn users only if KL < -1

cc @lvwerra 

related: https://github.com/lvwerra/trl/issues/351