### PR TITLE
stack_llama: update instructions in README, fix broken _get_submodules and save tokenizer

### DIFF
--- a/examples/stack_llama/scripts/README.md
+++ b/examples/stack_llama/scripts/README.md
@@ -13,5 +13,6 @@ At each stage the peft adapter layers were merged with the base model, using:
 ```shell
 python examples/stack_llama/scripts/merge_peft_adapter.py --adapter_model_name=XXX --base_model_name=YYY --output_name=ZZZ
 ```
+Note that this script requires `peft>=0.3.0`.
 
 For access to the base llama-7b model, please see Meta's [release](https://ai.facebook.com/blog/large-language-model-llama-meta-ai/) and [request form](https://docs.google.com/forms/d/e/1FAIpQLSfqNECQnMkycAp2jP4Z9TFX0cGR4uf7b_fBxjY_OjhJILlKGA/viewform).

--- a/examples/stack_llama/scripts/README.md
+++ b/examples/stack_llama/scripts/README.md
@@ -11,7 +11,7 @@ There were three main steps to the training process:
 LoRA layers were using at all stages to reduce memory requirements. 
 At each stage the peft adapter layers were merged with the base model, using: 
 ```shell
-python merge_peft_adapter.py --model_id=XXX --base_model_id=YYY --output_name=ZZZ
+python examples/stack_llama/scripts/merge_peft_adapter.py --adapter_model_name=XXX --base_model_name=YYY --output_name=ZZZ
 ```
 
 For access to the base llama-7b model, please see Meta's [release](https://ai.facebook.com/blog/large-language-model-llama-meta-ai/) and [request form](https://docs.google.com/forms/d/e/1FAIpQLSfqNECQnMkycAp2jP4Z9TFX0cGR4uf7b_fBxjY_OjhJILlKGA/viewform).

--- a/examples/stack_llama/scripts/merge_peft_adapter.py
+++ b/examples/stack_llama/scripts/merge_peft_adapter.py
@@ -62,4 +62,5 @@ for key in key_list:
 model = model.base_model.model
 
 model.save_pretrained(f"{script_args.output_name}")
+tokenizer.save_pretrained(f"{script_args.output_name}")
 model.push_to_hub(f"{script_args.output_name}", use_temp_dir=False)

--- a/examples/stack_llama/scripts/merge_peft_adapter.py
+++ b/examples/stack_llama/scripts/merge_peft_adapter.py
@@ -4,6 +4,7 @@ from typing import Optional
 import peft
 import torch
 from peft import PeftConfig, PeftModel
+from peft.utils import _get_submodules
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, HfArgumentParser
 
 
@@ -52,7 +53,7 @@ model.eval()
 
 key_list = [key for key, _ in model.base_model.model.named_modules() if "lora" not in key]
 for key in key_list:
-    parent, target, target_name = model.base_model._get_submodules(key)
+    parent, target, target_name = _get_submodules(model.base_model.model, key)
     if isinstance(target, peft.tuners.lora.Linear):
         bias = target.bias is not None
         new_module = torch.nn.Linear(target.in_features, target.out_features, bias=bias)


### PR DESCRIPTION
* The parameter names for `merge_peft_adapetr.py` are out of date in the README
* LlamaModelForCausalLM does not have an attribute `_get_submodules`