### PR TITLE
add is_trainable in kwargs

### DIFF
--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -107,9 +107,11 @@ class PreTrainedModelWrapper(nn.Module):
         """
         if kwargs is not None:
             peft_config = kwargs.pop("peft_config", None)
+            is_trainable = kwargs.pop("is_trainable", False)
             trl_model_args, pretrained_kwargs, peft_int8_kwargs = cls._split_kwargs(kwargs)
         else:
             peft_config = None
+            is_trainable = False
             trl_model_args = {}
             pretrained_kwargs = {}
             peft_int8_kwargs = {}
@@ -163,7 +165,9 @@ class PreTrainedModelWrapper(nn.Module):
                     peft_config.base_model_name_or_path, *model_args, **pretrained_kwargs
                 )
 
-                pretrained_model = PeftModel.from_pretrained(pretrained_model, pretrained_model_name_or_path)
+                pretrained_model = PeftModel.from_pretrained(
+                    pretrained_model, pretrained_model_name_or_path, is_trainable=is_trainable
+                )
             else:
                 pretrained_model = cls.transformers_parent_class.from_pretrained(
                     pretrained_model_name_or_path, *model_args, **pretrained_kwargs


### PR DESCRIPTION
# What does this PR do?

This PR enables continue training of peft model by add `is_trainable` as a `kwarg` on `from_pretained` of `PreTrainedWrapper`. (ref. https://github.com/lvwerra/trl/pull/342#discussion_r1191286149)

`is_trainable` is a parameter of `PeftModel.from_pretrained()` which enable continue training. `LoraConfig` do not have `is_trainable` parameter. 

Use case example: https://github.com/huggingface/peft/issues/282#issuecomment-1500804381
Source: https://github.com/huggingface/peft/blob/main/src/peft/peft_model.py#L145

cc @lvwerra @younesbelkada 