### PR TITLE
Remove obsolete layer_norm_names parameter and add peft>=0.3.0 to requirements

### DIFF
--- a/examples/sentiment/scripts/gpt-neox-20b_peft/clm_finetune_peft_imdb.py
+++ b/examples/sentiment/scripts/gpt-neox-20b_peft/clm_finetune_peft_imdb.py
@@ -59,9 +59,7 @@ if tokenizer.pad_token_id is None:
 
 
 if "gpt-neox" in model_args.model_name_or_path:
-    model = prepare_model_for_int8_training(
-        model, output_embedding_layer_name="embed_out"
-    )
+    model = prepare_model_for_int8_training(model, output_embedding_layer_name="embed_out")
 else:
     model = prepare_model_for_int8_training(model)
 

--- a/examples/sentiment/scripts/gpt-neox-20b_peft/clm_finetune_peft_imdb.py
+++ b/examples/sentiment/scripts/gpt-neox-20b_peft/clm_finetune_peft_imdb.py
@@ -60,7 +60,7 @@ if tokenizer.pad_token_id is None:
 
 if "gpt-neox" in model_args.model_name_or_path:
     model = prepare_model_for_int8_training(
-        model, output_embedding_layer_name="embed_out", layer_norm_names=["layer_norm", "layernorm"]
+        model, output_embedding_layer_name="embed_out"
     )
 else:
     model = prepare_model_for_int8_training(model)

--- a/examples/sentiment/scripts/gpt2-sentiment_peft.py
+++ b/examples/sentiment/scripts/gpt2-sentiment_peft.py
@@ -152,7 +152,6 @@ model = AutoModelForCausalLMWithValueHead.from_pretrained(
     config.model_name,
     load_in_8bit=True,
     peft_config=lora_config,
-    layer_norm_names=[],
 )
 
 tokenizer = AutoTokenizer.from_pretrained(config.model_name)

--- a/examples/stack_llama/scripts/rl_training.py
+++ b/examples/stack_llama/scripts/rl_training.py
@@ -183,7 +183,6 @@ model = AutoModelForCausalLMWithValueHead.from_pretrained(
     load_in_8bit=True,
     device_map={"": current_device},
     peft_config=lora_config,
-    layer_norm_names=[],
 )
 
 optimizer = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ torch>=1.4.0
 tqdm
 transformers
 accelerate
+pert>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ torch>=1.4.0
 tqdm
 transformers
 accelerate
-pert>=0.3.0
+peft>=0.3.0


### PR DESCRIPTION
The recent changes in `peft` break some of the scripts. E.g., `rl_training` passes the obsolete parameter `layer_norm_names` to the `pretrained_model` call as it detects that it is not consumed by `prepare_model_for_int8_training`, causing an error. Fix: remove all references to `layer_norm_names` and add `peft>=0.3.0` to `requirements.txt`.