### PR TITLE
from_pretrain with peft adapter on the hub (# 379)

### DIFF
--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -140,13 +140,12 @@ class PreTrainedModelWrapper(nn.Module):
         # either `AutoModelForCausalLM` or `AutoModelForSeq2SeqLM`
         if isinstance(pretrained_model_name_or_path, str):
             try:
+                # If there is a trained peft adapter in the hub or locally, load its config.
+                # The `peft` config is a file called "adapter_config.json"
                 trained_adapter_config = PeftConfig.from_pretrained(pretrained_model_name_or_path)
             except:  # noqa
                 trained_adapter_config = None
 
-            # Dealing with `peft` case:
-            # 1- If `adapter_config` has been saved in the hub or locally, load the `peft` config
-            # 2- use the config to load the `transformers` model and then load the `peft` model
             if trained_adapter_config is not None:
                 if peft_config is not None:
                     logging.warning(


### PR DESCRIPTION
I also added a warning in case an adapter is found but a peft_config is also given. And I tried to simplify a bit since the same processing is done in PeftConfig.from_pretrained.

is_peft_available() is indirectly checked. If it is not installed, it will trigger an exception and trained_adapter_config will be set to None.

Let me know what you think. If you don't think this is an improvement, I can revert, no problem.