### PR TITLE
Fixed some type annotations of trl.trainer.PPoTrainer

### DIFF
--- a/examples/sentiment/notebooks/gpt2-sentiment-control.ipynb
+++ b/examples/sentiment/notebooks/gpt2-sentiment-control.ipynb
@@ -721,10 +721,7 @@
    "source": [
     "for epoch in range(2):\n",
     "    for batch in tqdm(ppo_trainer.dataloader):\n",
-    "        (\n",
-    "            logs,\n",
-    "            game_data,\n",
-    "        ) = (\n",
+    "        (logs, game_data,) = (\n",
     "            dict(),\n",
     "            dict(),\n",
     "        )\n",

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -14,9 +14,9 @@
 import inspect
 import os
 import time
+import typing
 import warnings
 from typing import Callable, List, Optional, Union
-import typing
 
 import datasets
 import torch
@@ -27,8 +27,8 @@ from packaging import version
 from torch.optim import Adam
 from transformers import (
     DataCollatorForLanguageModeling,
-    PreTrainedTokenizerBase,
     PreTrainedTokenizer,
+    PreTrainedTokenizerBase,
     PreTrainedTokenizerFast,
 )
 

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -16,6 +16,7 @@ import os
 import time
 import warnings
 from typing import Callable, List, Optional, Union
+import typing
 
 import datasets
 import torch
@@ -24,7 +25,12 @@ from datasets import Dataset
 from huggingface_hub import whoami
 from packaging import version
 from torch.optim import Adam
-from transformers import DataCollatorForLanguageModeling, PreTrainedTokenizerBase
+from transformers import (
+    DataCollatorForLanguageModeling,
+    PreTrainedTokenizerBase,
+    PreTrainedTokenizer,
+    PreTrainedTokenizerFast,
+)
 
 from ..core import (
     WANDB_PADDING,

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -24,7 +24,7 @@ from datasets import Dataset
 from huggingface_hub import whoami
 from packaging import version
 from torch.optim import Adam
-from transformers import DataCollatorForLanguageModeling, PreTrainedTokenizer, PreTrainedTokenizerFast
+from transformers import DataCollatorForLanguageModeling, PreTrainedTokenizerBase
 
 from ..core import (
     WANDB_PADDING,
@@ -106,7 +106,7 @@ class PPOTrainer(BaseTrainer):
             transformer model with a casual language modelling head. Check the documentation of `PreTrainedModelWrapper`
             for more details. If no reference model is provided, the trainer will create a reference model with the same
              architecture as the model to be optimized with shared layers.
-        **tokenizer** (`Union[PreTrainedTokenizer, PreTrainedTokenizerFast]`) -- Tokenizer to be used for encoding the
+        **tokenizer** (`PreTrainedTokenizerBase`) -- Tokenizer to be used for encoding the
             data. Check the documentation of `transformers.PreTrainedTokenizer` and
             `transformers.PreTrainedTokenizerFast` for more details.
         **dataset** (Union[`torch.utils.data.Dataset`, `datasets.Dataset`], *optional*) -- PyTorch dataset or Hugging
@@ -127,11 +127,11 @@ class PPOTrainer(BaseTrainer):
         self,
         config: PPOConfig = None,
         model: PreTrainedModelWrapper = None,
-        ref_model: PreTrainedModelWrapper = None,
-        tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast] = None,
+        ref_model: Optional[PreTrainedModelWrapper] = None,
+        tokenizer: PreTrainedTokenizerBase = None,
         dataset: Optional[Union[torch.utils.data.Dataset, Dataset]] = None,
         optimizer: Optional[torch.optim.Optimizer] = None,
-        data_collator=None,
+        data_collator: Optional[typing.Callable] = None,
         num_shared_layers: Optional[int] = None,
         lr_scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
     ):
@@ -145,9 +145,9 @@ class PPOTrainer(BaseTrainer):
                 Hugging Face transformer model with a value head.
             ref_model (`PreTrainedModelWrapper`):
                 Hugging Face transformer model with a casual language modelling head. Used for KL penalty
-            tokenizer (`transformers.PreTrainedTokenizer`):
+            tokenizer (`transformers.PreTrainedTokenizerBase`):
                 Hugging Face tokenizer
-            dataset (Union[`torch.utils.data.Dataset`, `datasets.Dataset`], *optional*):
+            dataset (Optional[Union[`torch.utils.data.Dataset`, `datasets.Dataset`]]):
                 PyTorch dataset or Hugging Face dataset. If a Hugging Face dataset is passed, the dataset
                 will be preprocessed by removing the columns that are not used by the model. If none is passed,
                 a warning will be raised in a multi-GPU setting.
@@ -169,9 +169,9 @@ class PPOTrainer(BaseTrainer):
         # Step 0: check positional arguments validity
         if not isinstance(config, PPOConfig):
             raise ValueError(f"config must be a PPOConfig, got {type(config)}")
-        if not isinstance(tokenizer, (PreTrainedTokenizer, PreTrainedTokenizerFast)):
+        if not isinstance(tokenizer, (PreTrainedTokenizerBase)):
             raise ValueError(
-                f"tokenizer must be a PreTrainedTokenizer or PreTrainedTokenizerFast, got {type(tokenizer)}"
+                f"tokenizer must be a PreTrainedTokenizerBase like a PreTrainedTokenizer or a PreTrainedTokenizerFast, got {type(tokenizer)}"
             )
         if not isinstance(model, (SUPPORTED_ARCHITECTURES)):
             raise ValueError(


### PR DESCRIPTION
- Ref model should be Optional
- The usual annotation for the Huggingface tokenizers is PreTrainedTokenizerBase. Not using that messes up people's annotation checks.
- Fixed the comments wrt the other two points