### PR TITLE
keep state_dict kwargs instead of popping it in save_pretrained

### DIFF
--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -339,7 +339,7 @@ class PreTrainedModelWrapper(nn.Module):
                 Keyword arguments passed along to the underlying model's
                 `save_pretrained` method.
         """
-        state_dict = kwargs.pop("state_dict", None)
+        state_dict = kwargs.get("state_dict")
         if state_dict is None:
             state_dict = self.state_dict()
             kwargs["state_dict"] = state_dict


### PR DESCRIPTION
This PR fixes the following issue: when `save_pretrained(...)` was called for `AutoModelForCausalLMWithValueHead` with an explicitly given `state_dict`, this `state_dict` was deleted from `kwargs` and not passed further. I believe the intended behavior was to keep `state_dict` in `kwargs` if it's already in there. 