### PR TITLE
StackLLaMA: fix supervised finetuning and reward model training

### DIFF
--- a/examples/stack_llama/scripts/reward_modeling.py
+++ b/examples/stack_llama/scripts/reward_modeling.py
@@ -8,7 +8,6 @@ import torch.nn as nn
 from datasets import load_dataset
 from peft import LoraConfig, TaskType, get_peft_model
 from transformers import (
-    AutoConfig,
     AutoModelForSequenceClassification,
     AutoTokenizer,
     HfArgumentParser,
@@ -27,9 +26,7 @@ class ScriptArguments:
     These arguments vary depending on how many GPUs you have, what their capacity and features are, and what size model you want to train.
     """
 
-    local_rank: Optional[int] = field(
-        default=-1, metadata={"help": "Used for multi-gpu"}
-    )
+    local_rank: Optional[int] = field(default=-1, metadata={"help": "Used for multi-gpu"})
     resume_from_checkpoint: Optional[bool] = field(
         default=False,
         metadata={"help": "If you want to resume training where it left off."},
@@ -98,19 +95,17 @@ parser = HfArgumentParser(ScriptArguments)
 script_args = parser.parse_args_into_dataclasses()[0]
 
 # Load the human stack-exchange-paired dataset for tuning the reward model.
-train_dataset = load_dataset(
-    "lvwerra/stack-exchange-paired", data_dir="data/reward", split="train"
-)
+train_dataset = load_dataset("lvwerra/stack-exchange-paired", data_dir="data/reward", split="train")
 if script_args.train_subset > 0:
     train_dataset = train_dataset.select(range(script_args.train_subset))
-eval_dataset = load_dataset(
-    "lvwerra/stack-exchange-paired", data_dir="data/evaluation", split="train"
-)
+eval_dataset = load_dataset("lvwerra/stack-exchange-paired", data_dir="data/evaluation", split="train")
 if script_args.eval_subset > 0:
     eval_dataset = eval_dataset.select(range(script_args.eval_subset))
 # Define the training args. Needs to be done before the model is loaded if you are using deepspeed.
 model_name_split = script_args.model_name.split("/")[-1]
-output_name = f"{model_name_split}_peft_stack-exchange-paired_rmts__{script_args.train_subset}_{script_args.learning_rate}"
+output_name = (
+    f"{model_name_split}_peft_stack-exchange-paired_rmts__{script_args.train_subset}_{script_args.learning_rate}"
+)
 
 training_args = TrainingArguments(
     output_dir=output_name,
@@ -136,11 +131,7 @@ training_args = TrainingArguments(
     lr_scheduler_type=script_args.lr_scheduler_type,
 )
 # Load the value-head model and tokenizer.
-tokenizer_name = (
-    script_args.tokenizer_name
-    if script_args.tokenizer_name is not None
-    else script_args.model_name
-)
+tokenizer_name = script_args.tokenizer_name if script_args.tokenizer_name is not None else script_args.model_name
 tokenizer = AutoTokenizer.from_pretrained(tokenizer_name, use_auth_token=True)
 tokenizer.pad_token = tokenizer.eos_token
 
@@ -176,15 +167,9 @@ def preprocess_function(examples):
         "input_ids_k": [],
         "attention_mask_k": [],
     }
-    for question, response_j, response_k in zip(
-        examples["question"], examples["response_j"], examples["response_k"]
-    ):
-        tokenized_j = tokenizer(
-            "Question: " + question + "\n\nAnswer: " + response_j, truncation=True
-        )
-        tokenized_k = tokenizer(
-            "Question: " + question + "\n\nAnswer: " + response_k, truncation=True
-        )
+    for question, response_j, response_k in zip(examples["question"], examples["response_j"], examples["response_k"]):
+        tokenized_j = tokenizer("Question: " + question + "\n\nAnswer: " + response_j, truncation=True)
+        tokenized_k = tokenizer("Question: " + question + "\n\nAnswer: " + response_k, truncation=True)
 
         new_examples["input_ids_j"].append(tokenized_j["input_ids"])
         new_examples["attention_mask_j"].append(tokenized_j["attention_mask"])
@@ -202,8 +187,7 @@ train_dataset = train_dataset.map(
     remove_columns=original_columns,
 )
 train_dataset = train_dataset.filter(
-    lambda x: len(x["input_ids_j"]) <= script_args.max_length
-    and len(x["input_ids_k"]) <= script_args.max_length
+    lambda x: len(x["input_ids_j"]) <= script_args.max_length and len(x["input_ids_k"]) <= script_args.max_length
 )
 
 eval_dataset = eval_dataset.map(
@@ -213,8 +197,7 @@ eval_dataset = eval_dataset.map(
     remove_columns=original_columns,
 )
 eval_dataset = eval_dataset.filter(
-    lambda x: len(x["input_ids_j"]) <= script_args.max_length
-    and len(x["input_ids_k"]) <= script_args.max_length
+    lambda x: len(x["input_ids_j"]) <= script_args.max_length and len(x["input_ids_k"]) <= script_args.max_length
 )
 
 
@@ -283,12 +266,8 @@ def compute_metrics(eval_pred):
 class RewardTrainer(Trainer):
     # Define how to compute the reward loss. We use the InstructGPT pairwise logloss: https://arxiv.org/abs/2203.02155
     def compute_loss(self, model, inputs, return_outputs=False):
-        rewards_j = model(
-            input_ids=inputs["input_ids_j"], attention_mask=inputs["attention_mask_j"]
-        )[0]
-        rewards_k = model(
-            input_ids=inputs["input_ids_k"], attention_mask=inputs["attention_mask_k"]
-        )[0]
+        rewards_j = model(input_ids=inputs["input_ids_j"], attention_mask=inputs["attention_mask_j"])[0]
+        rewards_k = model(input_ids=inputs["input_ids_k"], attention_mask=inputs["attention_mask_k"])[0]
         loss = -nn.functional.logsigmoid(rewards_j - rewards_k).mean()
         if return_outputs:
             return loss, {"rewards_j": rewards_j, "rewards_k": rewards_k}
@@ -302,13 +281,12 @@ trainer = RewardTrainer(
     train_dataset=train_dataset,
     eval_dataset=eval_dataset,
     compute_metrics=compute_metrics,
-    data_collator=RewardDataCollatorWithPadding(
-        tokenizer=tokenizer, max_length=script_args.max_length
-    ),
+    data_collator=RewardDataCollatorWithPadding(tokenizer=tokenizer, max_length=script_args.max_length),
 )
 
 
 if script_args.eval_first_step:
+
     class EvaluateFirstStepCallback(TrainerCallback):
         def on_step_end(self, args, state, control, **kwargs):
             if state.global_step == 1:

--- a/examples/stack_llama/scripts/supervised_finetuning.py
+++ b/examples/stack_llama/scripts/supervised_finetuning.py
@@ -5,7 +5,13 @@ from accelerate import Accelerator
 from datasets import load_dataset
 from peft import LoraConfig
 from tqdm import tqdm
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, TrainingArguments, logging, set_seed
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    TrainingArguments,
+    logging,
+    set_seed,
+)
 
 from trl import SFTTrainer
 from trl.trainer import ConstantLengthDataset
@@ -19,7 +25,9 @@ Fine-Tune Llama-7b on SE paired dataset
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model_path", type=str, default="")
-    parser.add_argument("--dataset_name", type=str, default="lvwerra/stack-exchange-paired")
+    parser.add_argument(
+        "--dataset_name", type=str, default="lvwerra/stack-exchange-paired"
+    )
     parser.add_argument("--subset", type=str, default="data/finetune")
     parser.add_argument("--split", type=str, default="train")
     parser.add_argument("--size_valid_set", type=int, default=4000)
@@ -40,7 +48,9 @@ def get_args():
     parser.add_argument("--local_rank", type=int, default=0)
     parser.add_argument("--no_fp16", action="store_false")
     parser.add_argument("--bf16", action="store_true", default=False)
-    parser.add_argument("--no_gradient_checkpointing", action="store_false", default=False)
+    parser.add_argument(
+        "--no_gradient_checkpointing", action="store_false", default=False
+    )
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--num_workers", type=int, default=None)
     parser.add_argument("--output_dir", type=str, default="./checkpoints")
@@ -106,7 +116,9 @@ def create_datasets(tokenizer, args):
         dataset = dataset.train_test_split(test_size=0.005, seed=args.seed)
         train_data = dataset["train"]
         valid_data = dataset["test"]
-        print(f"Size of the train set: {len(train_data)}. Size of the validation set: {len(valid_data)}")
+        print(
+            f"Size of the train set: {len(train_data)}. Size of the validation set: {len(valid_data)}"
+        )
 
     chars_per_token = chars_token_ratio(train_data, tokenizer)
     print(f"The character to token ratio of the dataset is: {chars_per_token:.2f}")
@@ -191,21 +203,7 @@ def run_training(args, train_data, val_data):
 
 
 def main(args):
-    config = AutoConfig.from_pretrained(args.model_path)
-    architecture = config.architectures[0]
-
     tokenizer = AutoTokenizer.from_pretrained(args.model_path)
-
-    if "Llama" in architecture:
-        print("Setting EOS, BOS, and UNK tokens for LLama tokenizer")
-        tokenizer.add_special_tokens(
-            {
-                "eos_token": "</s>",
-                "bos_token": "</s>",
-                "unk_token": "</s>",
-            }
-        )
-
     train_dataset, eval_dataset = create_datasets(tokenizer, args)
     run_training(args, train_dataset, eval_dataset)
 

--- a/examples/stack_llama/scripts/supervised_finetuning.py
+++ b/examples/stack_llama/scripts/supervised_finetuning.py
@@ -5,13 +5,7 @@ from accelerate import Accelerator
 from datasets import load_dataset
 from peft import LoraConfig
 from tqdm import tqdm
-from transformers import (
-    AutoModelForCausalLM,
-    AutoTokenizer,
-    TrainingArguments,
-    logging,
-    set_seed,
-)
+from transformers import AutoModelForCausalLM, AutoTokenizer, TrainingArguments, logging, set_seed
 
 from trl import SFTTrainer
 from trl.trainer import ConstantLengthDataset
@@ -25,9 +19,7 @@ Fine-Tune Llama-7b on SE paired dataset
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model_path", type=str, default="")
-    parser.add_argument(
-        "--dataset_name", type=str, default="lvwerra/stack-exchange-paired"
-    )
+    parser.add_argument("--dataset_name", type=str, default="lvwerra/stack-exchange-paired")
     parser.add_argument("--subset", type=str, default="data/finetune")
     parser.add_argument("--split", type=str, default="train")
     parser.add_argument("--size_valid_set", type=int, default=4000)
@@ -48,9 +40,7 @@ def get_args():
     parser.add_argument("--local_rank", type=int, default=0)
     parser.add_argument("--no_fp16", action="store_false")
     parser.add_argument("--bf16", action="store_true", default=False)
-    parser.add_argument(
-        "--no_gradient_checkpointing", action="store_false", default=False
-    )
+    parser.add_argument("--no_gradient_checkpointing", action="store_false", default=False)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--num_workers", type=int, default=None)
     parser.add_argument("--output_dir", type=str, default="./checkpoints")
@@ -116,9 +106,7 @@ def create_datasets(tokenizer, args):
         dataset = dataset.train_test_split(test_size=0.005, seed=args.seed)
         train_data = dataset["train"]
         valid_data = dataset["test"]
-        print(
-            f"Size of the train set: {len(train_data)}. Size of the validation set: {len(valid_data)}"
-        )
+        print(f"Size of the train set: {len(train_data)}. Size of the validation set: {len(valid_data)}")
 
     chars_per_token = chars_token_ratio(train_data, tokenizer)
     print(f"The character to token ratio of the dataset is: {chars_per_token:.2f}")


### PR DESCRIPTION
for supervised finetuning
- removed tokenizer hacks since they are no longer necessary with the updated `llamatokenizer`
- black + isort

for reward modeling
- added `tokenizer_name` so it can be separately specified from model
- again removed old llama tokenizer hacks
- added `eval_first_step` option to add an eval loop after the first step to make nicer graphs
- black + isort