### PR TITLE
Resolve broken evaluation/prediction for RewardTrainer

### DIFF
--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -102,7 +102,7 @@ class RewardTrainerTester(unittest.TestCase):
                     self.assertFalse(torch.equal(param, new_param))
 
             preds = trainer.predict(dummy_dataset)
-            assert preds.predictions.shape == (4, 2)
+            self.assertEqual(preds.predictions.shape, (4, 2))
 
     @require_peft
     def test_reward_trainer_peft(self):
@@ -197,7 +197,7 @@ class RewardTrainerTester(unittest.TestCase):
                 self.assertTrue(torch.allclose(param, new_param, atol=1e-12, rtol=1e-12))
 
             preds = trainer.predict(dummy_dataset)
-            assert preds.predictions.shape == (4, 2)
+            self.assertEqual(preds.predictions.shape, (4, 2))
 
     def test_reward_trainer_assert_value_error(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -47,7 +47,6 @@ class RewardTrainerTester(unittest.TestCase):
                 gradient_accumulation_steps=4,
                 learning_rate=9e-1,
                 evaluation_strategy="steps",
-                eval_steps=1,
             )
 
             # fmt: off
@@ -128,7 +127,6 @@ class RewardTrainerTester(unittest.TestCase):
                 gradient_accumulation_steps=4,
                 learning_rate=9e-1,
                 evaluation_strategy="steps",
-                eval_steps=1,
             )
 
             # fmt: off

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -189,7 +189,8 @@ class RewardTrainer(Trainer):
             else:
                 ignore_keys = []
 
-        loss, logits_dict = self.compute_loss(model, inputs, return_outputs=True)
+        with torch.no_grad():
+            loss, logits_dict = self.compute_loss(model, inputs, return_outputs=True)
 
         if prediction_loss_only:
             return (loss, None, None)

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import warnings
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -20,6 +20,7 @@ import torch.nn as nn
 from datasets import Dataset
 from transformers import DataCollator, PreTrainedModel, PreTrainedTokenizerBase, Trainer, TrainingArguments
 from transformers.trainer_callback import TrainerCallback
+from transformers.trainer_pt_utils import nested_detach
 from transformers.trainer_utils import EvalPrediction
 
 from ..import_utils import is_peft_available
@@ -30,14 +31,13 @@ if is_peft_available():
     from peft import get_peft_model
 
 
-def compute_accuracy(eval_pred):
-    predictions, _ = eval_pred
+def compute_accuracy(eval_pred) -> Dict[Literal["accuracy"], float]:
+    predictions, labels = eval_pred
     # Here, predictions is rewards_chosen and rewards_rejected.
     # We want to see how much of the time rewards_chosen > rewards_rejected.
-    predictions = np.argmax(predictions, axis=0)
-    labels = np.zeros(predictions.shape)
+    predictions = np.argmax(predictions, axis=1)
 
-    accuracy = np.mean([p == l for p, l in zip(predictions, labels)])
+    accuracy = np.array(predictions == labels, dtype=float).mean().item()
     return {"accuracy": accuracy}
 
 
@@ -156,7 +156,12 @@ class RewardTrainer(Trainer):
             preprocess_logits_for_metrics,
         )
 
-    def compute_loss(self, model, inputs, return_outputs=False):
+    def compute_loss(
+        self,
+        model: Union[PreTrainedModel, nn.Module],
+        inputs: Dict[str, Union[torch.Tensor, Any]],
+        return_outputs=False,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
         if not self.use_reward_data_collator:
             raise NotImplementedError(
                 "compute_loss is only implemented for RewardDataCollatorWithPadding, please implement your own compute_loss method if you are using a custom data collator"
@@ -169,3 +174,33 @@ class RewardTrainer(Trainer):
         if return_outputs:
             return loss, {"rewards_chosen": rewards_chosen, "rewards_rejected": rewards_rejected}
         return loss
+
+    def prediction_step(
+        self,
+        model: Union[PreTrainedModel, nn.Module],
+        inputs: Dict[str, Union[torch.Tensor, Any]],
+        prediction_loss_only: bool,
+        ignore_keys: Optional[List[str]] = None,
+    ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
+        inputs = self._prepare_inputs(inputs)
+        if ignore_keys is None:
+            if hasattr(self.model, "config"):
+                ignore_keys = getattr(self.model.config, "keys_to_ignore_at_inference", [])
+            else:
+                ignore_keys = []
+
+        loss, logits_dict = self.compute_loss(model, inputs, return_outputs=True)
+
+        if prediction_loss_only:
+            return (loss, None, None)
+
+        loss = loss.detach()
+        logits = tuple(v for k, v in logits_dict.items() if k not in ignore_keys)
+        logits = nested_detach(logits)
+        # Stack accepted against rejected, mean over logits
+        # and softmax to get preferences between accepted and rejected to sum to 1
+        logits = torch.stack(logits).mean(dim=2).softmax(dim=0).T
+
+        labels = torch.zeros(logits.shape[0])
+
+        return loss, logits, labels

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import warnings
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -31,7 +31,7 @@ if is_peft_available():
     from peft import get_peft_model
 
 
-def compute_accuracy(eval_pred) -> Dict[Literal["accuracy"], float]:
+def compute_accuracy(eval_pred) -> Dict[str, float]:
     predictions, labels = eval_pred
     # Here, predictions is rewards_chosen and rewards_rejected.
     # We want to see how much of the time rewards_chosen > rewards_rejected.


### PR DESCRIPTION
Hello!

## Pull Request overview
* Implement evaluation & prediction for `RewardTrainer`.
  * Update `compute_average` correspondingly.
* Adapt tests to perform both evaluation and prediction.
* Improve typing for the RewardTrainer.

## Motivation
In our attempts to apply the `RewardTrainer`, we experienced issues with the evaluation. See below our training script for reference:

<details><summary>Training script</summary>

```python
from datasets import load_dataset
from transformers import (
    AutoModelForSequenceClassification,
    AutoTokenizer,
    TrainingArguments,
)
from trl import RewardTrainer

dataset = load_dataset("argilla/dolly-curated-comparison-falcon-7b-instruct", split="train")
model_name = "distilroberta-base"
model = AutoModelForSequenceClassification.from_pretrained(model_name, num_labels=1)
tokenizer = AutoTokenizer.from_pretrained(model_name)

if tokenizer.pad_token is None:
    tokenizer.pad_token = tokenizer.eos_token
    model.config.pad_token_id = model.config.eos_token_id

def formatting_func(examples):
    kwargs = {"padding": "max_length", "truncation": True, "max_length": 512, "return_tensors": "pt"}

    # Prepend the prompt and a line break to the original_response and response-1 fields.
    prompt_plus_chosen_response = examples["prompt"] + "\n" + examples["original_response"]
    prompt_plus_rejected_response = examples["prompt"] + "\n" + examples["response-1"]

    # Then tokenize these modified fields.
    tokens_chosen = tokenizer.encode_plus(prompt_plus_chosen_response, **kwargs)
    tokens_rejected = tokenizer.encode_plus(prompt_plus_rejected_response, **kwargs)

    return {
        "input_ids_chosen": tokens_chosen["input_ids"][0], "attention_mask_chosen": tokens_chosen["attention_mask"][0],
        "input_ids_rejected": tokens_rejected["input_ids"][0], "attention_mask_rejected": tokens_rejected["attention_mask"][0]
    }
    
formatted_dataset = dataset.map(formatting_func)

formatted_dataset = formatted_dataset.train_test_split()

training_args = TrainingArguments(
    output_dir="./my_model",
    per_device_train_batch_size=16,
    evaluation_strategy="steps",
    logging_steps=100,  
)

trainer = RewardTrainer(
    model=model,
    args=training_args,
    tokenizer=tokenizer,
    train_dataset=formatted_dataset["train"],
    eval_dataset=formatted_dataset["test"],
)

trainer.train()
```
</details>

When training, we experience the following error:
```
Traceback (most recent call last):
  File "[sic]\trl\demo2.py", line 53, in <module>
    trainer.train()
  File "[sic]\trl\lib\site-packages\transformers\trainer.py", line 1664, in train
    return inner_training_loop(
  File "[sic]\trl\lib\site-packages\transformers\trainer.py", line 2019, in _inner_training_loop
    self._maybe_log_save_evaluate(tr_loss, model, trial, epoch, ignore_keys_for_eval)
  File "[sic]\trl\lib\site-packages\transformers\trainer.py", line 2300, in _maybe_log_save_evaluate
    metrics = self.evaluate(ignore_keys=ignore_keys_for_eval)
  File "[sic]\trl\lib\site-packages\transformers\trainer.py", line 3029, in evaluate
    output = eval_loop(
  File "[sic]\trl\lib\site-packages\transformers\trainer.py", line 3210, in evaluation_loop
    loss, logits, labels = self.prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)
  File "[sic]\trl\lib\site-packages\transformers\trainer.py", line 3476, in prediction_step
    outputs = model(**inputs)
  File "[sic]\trl\lib\site-packages\torch\nn\modules\module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
TypeError: forward() got an unexpected keyword argument 'input_ids_chosen
```

The cause of this bug is pretty straight-forward: the unchanged transformers Trainer evaluation/prediction loop is used, while we need a special loop that makes forward passes for both the accepted and the rejected input_ids/attention_masks.

## The fix
The fix is as simple as overriding `prediction_step` such that the primary changes relative to the original `prediction_step` are:
1. We use `compute_loss` for the forward calls instead of `model(**inputs)`.
2. Get the mean of the logits for each of the samples & apply a softmax so the reward for the accepted plus the reward for the rejected sum to 1. 
3. We fix the labels to be a vector of 0's: we always prefer the accepted samples (i.e. index 0).

Because of this last change, we can simplify the `compute_average` to actually use the labels.
Lastly, I updated the typing on `compute_loss`. I recognize that the contributor guidelines specify to make those changes separately - I apologize for that.

## The consequences
With these changes in place, we can run the above script just fine:
![image](https://github.com/lvwerra/trl/assets/37621491/3476aa6a-e4e3-4400-b50f-310f394fcd7a)
(Although in practice, we just call the forward method of our trained model using individual samples to get the logits.)

Additionally, we can run `trainer.predict()` and get a useful response. See this dummy example using an untrained model.
```
PredictionOutput(predictions=array([[0.47846982, 0.52153015],
       [0.5010128 , 0.4989872 ],
       [0.47846982, 0.52153015],
       [0.44097137, 0.5590286 ]], dtype=float32), label_ids=array([0., 0., 0., 0.], dtype=float32), metrics={'test_loss': 0.7460569143295288, 'test_accuracy': 0.25, 'test_runtime': 0.0831, 'test_samples_per_second': 48.116, 'test_steps_per_second': 12.029})
```
As you can see, the test accuracy is 25%, because for only one of the predictions is the reward for the first sample better. 

## The tests
The tests are updated to add `evaluation_strategy="steps"`, otherwise the evaluation didn't trigger. Furthermore, I added `trainer.predict` calls that verify that the output is indeed of shape `(4, 2)` when there are 4 samples. 

Alternatively, I can update the predictions to only give the "probability" of the accepted sample, or to only give the argmax (e.g. [0, 1, 0, 0]) as the prediction.

cc: @younesbelkada @lewtun @lvwerra @dvsrepo

I'm open to feedback and suggestions as always.

- Tom Aarsen