### PR TITLE
Skip flaky test until next transformers release

### DIFF
--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -24,6 +24,7 @@ from trl.trainer import compute_accuracy
 from .testing_utils import require_peft
 
 
+@unittest.skip("skip until the next transformers release")
 class RewardTrainerTester(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Currently CIs on main are flaky due to a bug on transformers trainer: https://github.com/huggingface/transformers/pull/24049

cc @lvwerra 