### PR TITLE
Update test_reward_trainer.py

### DIFF
--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -24,7 +24,6 @@ from trl.trainer import compute_accuracy
 from .testing_utils import require_peft
 
 
-@unittest.skip("skip until the next transformers release")
 class RewardTrainerTester(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
With the new release of transformers, we can safely revert the skip test for the reward trainer

cc @lvwerra 