### PR TITLE
[`SFTTrainer`] Relax dataset constraints

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -234,6 +234,9 @@ class SFTTrainer(Trainer):
             )
         ):
             is_already_dataset = True
+        elif dataset is not None and isinstance(dataset, ConstantLengthDataset):
+            is_already_dataset = True
+            packing = True
         else:
             is_already_dataset = False
 


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/lvwerra/trl/issues/434

Fixes a small nit, when a user already passes a `ConstantLengthDataset`, the SFTTrainer should accept it out of the box, assuming users know what they did

