### PR TITLE
Pre-commit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,26 +7,24 @@ on:
     branches: [ main ]
 
 jobs:
-
   check_code_quality:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v2
         with:
-          python-version: "3.8"
-          cache: "pip"
-          cache-dependency-path: |
-            setup.py
-            requirements.txt
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .[dev]
-      - name: Check quality
-        run: |
-          make quality
+          fetch-depth: 0
+          submodules: recursive
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: pre-commit/action@v2.0.3
+        with:
+          extra_args: --all-files
 
   tests:
     needs: check_code_quality

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,10 +33,10 @@ repos:
           - --ignore=E203,E501,W503,E128
           - --max-line-length=119
 
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
-    hooks:
-      - id: codespell
-        args:
-          - --ignore-words-list=nd,reacher,thist,ths,magent,ba
-          - --skip=docs/css/termynal.css,docs/js/termynal.js
+  # - repo: https://github.com/codespell-project/codespell
+  #   rev: v2.1.0
+  #   hooks:
+  #     - id: codespell
+  #       args:
+  #         - --ignore-words-list=nd,reacher,thist,ths,magent,ba
+  #         - --skip=docs/css/termynal.css,docs/js/termynal.js

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+repos:
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args:
+          - --profile=black
+          - --skip-glob=wandb/**/*
+          - --thirdparty=wandb
+  - repo: https://github.com/myint/autoflake
+    rev: v1.4
+    hooks:
+      - id: autoflake
+        args:
+          - -r
+          - --exclude=wandb,__init__.py
+          - --in-place
+          - --remove-unused-variables
+          - --remove-all-unused-imports
+  - repo: https://github.com/python/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        args:
+          - --line-length=119
+          - --target-version=py38
+          - --exclude=wandb
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        args:
+          - --ignore=E203,E501,W503,E128
+          - --max-line-length=119
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        args:
+          - --ignore-words-list=nd,reacher,thist,ths,magent,ba
+          - --skip=docs/css/termynal.css,docs/js/termynal.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,10 +36,10 @@ First you want to make sure that all the tests pass:
 make test
 ```
 
-Then before submitting your PR make sure the code quality follows the standards. You can run the following command to format and test:
+Then before submitting your PR make sure the code quality follows the standards. You can run the following command to format:
 
 ```bash
-make style && make quality
+make commit
 ```
 
 ## Do you want to contribute to the documentation?

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-.PHONY: test commit
+.PHONY: test precommit
 
 check_dirs := examples tests trl
 
 test:
 	python -m pytest -n auto --dist=loadfile -s -v ./tests/
 
-commit:
+precommit:
 	pre-commit run --all-files

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,6 @@
-.PHONY: quality style test
+.PHONY: test
 
 check_dirs := examples tests trl
 
 test:
 	python -m pytest -n auto --dist=loadfile -s -v ./tests/
-
-quality:
-	black --check --line-length 119 --target-version py38 $(check_dirs)
-	isort --check-only $(check_dirs)
-	flake8 $(check_dirs)
-
-style:
-	black --line-length 119 --target-version py38 $(check_dirs)
-	isort $(check_dirs)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-.PHONY: test
+.PHONY: test commit
 
 check_dirs := examples tests trl
 
 test:
 	python -m pytest -n auto --dist=loadfile -s -v ./tests/
+
+commit:
+	pre-commit run --all-files

--- a/scripts/stale.py
+++ b/scripts/stale.py
@@ -15,8 +15,8 @@
 Script to close stale issue. Taken in part from the AllenNLP repository.
 https://github.com/allenai/allennlp.
 """
-from datetime import datetime as dt
 import os
+from datetime import datetime as dt
 
 from github import Github
 
@@ -37,7 +37,8 @@ def main():
         comments = sorted([comment for comment in issue.get_comments()], key=lambda i: i.created_at, reverse=True)
         last_comment = comments[0] if len(comments) > 0 else None
         if (
-            last_comment is not None and last_comment.user.login == "github-actions[bot]"
+            last_comment is not None
+            and last_comment.user.login == "github-actions[bot]"
             and (dt.utcnow() - issue.updated_at).days > 7
             and (dt.utcnow() - issue.created_at).days >= 30
             and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,3 @@ line_length = 119
 lines_after_imports = 2
 multi_line_output = 3
 use_parentheses = True
-
-[flake8]
-ignore = E203, E501, W503
-max-line-length = 119

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ To create the package for pypi.
    Then push the change with a message 'set dev version'
 """
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
 
 __version__ = "0.4.5.dev0"  # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
 
@@ -68,7 +69,7 @@ REQUIRED_PKGS = [
 EXTRAS = {
     "test": ["parameterized", "pytest", "pytest-xdist", "accelerate", "peft"],
     "peft": ["peft>=0.2.0"],
-    "dev": ["parameterized", "pytest", "pytest-xdist", "black", "isort", "flake8>=3.8.3", "peft>=0.2.0"],
+    "dev": ["parameterized", "pytest", "pytest-xdist", "pre-commit", "peft>=0.2.0"],
 }
 
 setup(


### PR DESCRIPTION
You can reproduce the existing pipeline with `pre-commit run --all-files` (note that pre-commit however only applies to git's staged and already committed files). I didn't fix the typo pointed out by `codespell` because it might create too many merge conflicts with existing PRs.

<img width="702" alt="image" src="https://github.com/lvwerra/trl/assets/5555347/0476cdcf-4783-40e2-94a6-e5ad47336826">
