### PR TITLE
[`ConstantLengthDataset`] Fix packed dataset issue

### DIFF
--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -98,6 +98,8 @@ trainer = SFTTrainer(
 trainer.train()
 ```
 
+Note that if you use a packed dataset and if you pass `max_steps` in the training arguments you will probably train your models for more than few epochs. 
+
 #### Customize your prompts using packed dataset
 
 If your dataset has several fields that you want to combine, for example if the dataset has `question` and `answer` fields and you want to combine them, you can pass a formatting function to the trainer that will take care of that. For example:

--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -98,7 +98,7 @@ trainer = SFTTrainer(
 trainer.train()
 ```
 
-Note that if you use a packed dataset and if you pass `max_steps` in the training arguments you will probably train your models for more than few epochs. 
+Note that if you use a packed dataset and if you pass `max_steps` in the training arguments you will probably train your models for more than few epochs, depending on the way you have configured the packed dataset and the training protocol. Double check that you know and understand what you are doing. 
 
 #### Customize your prompts using packed dataset
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -480,7 +480,7 @@ class SFTTrainerTester(unittest.TestCase):
             self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
 
             # make sure the trainer did 5 steps
-            self.assertTrue("pytorch_model.bin" in os.listdir(tmp_dir + "/checkpoint-2"))
+            self.assertTrue("pytorch_model.bin" in os.listdir(tmp_dir + "/checkpoint-4"))
 
     @require_peft
     def test_peft_sft_trainer(self):

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -423,6 +423,65 @@ class SFTTrainerTester(unittest.TestCase):
         result_text = self.tokenizer.decode(batch["input_ids"][0, last_pad_idx + 1 :])
         self.assertTrue(result_text == "I have not been masked correctly.")
 
+    def test_sft_trainer_infinite_with_model(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            training_args = TrainingArguments(
+                output_dir=tmp_dir,
+                dataloader_drop_last=True,
+                evaluation_strategy="steps",
+                max_steps=5,
+                eval_steps=1,
+                save_steps=1,
+                per_device_train_batch_size=2,
+            )
+
+            trainer = SFTTrainer(
+                model=self.model,
+                args=training_args,
+                train_dataset=self.train_dataset,
+                eval_dataset=self.eval_dataset,
+                packing=True,
+                max_seq_length=500,
+            )
+
+            self.assertTrue(trainer.train_dataset.infinite)
+
+            trainer.train()
+
+            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+            self.assertIsNotNone(trainer.state.log_history[0]["eval_loss"])
+
+            # make sure the trainer did 5 steps
+            self.assertTrue("pytorch_model.bin" in os.listdir(tmp_dir + "/checkpoint-5"))
+
+    def test_sft_trainer_infinite_with_model_epochs(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            training_args = TrainingArguments(
+                output_dir=tmp_dir,
+                dataloader_drop_last=True,
+                num_train_epochs=1,
+                per_device_train_batch_size=2,
+                save_strategy="epoch",
+            )
+
+            trainer = SFTTrainer(
+                model=self.model,
+                args=training_args,
+                train_dataset=self.train_dataset,
+                eval_dataset=self.eval_dataset,
+                packing=True,
+                max_seq_length=500,
+            )
+
+            self.assertFalse(trainer.train_dataset.infinite)
+
+            trainer.train()
+
+            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+
+            # make sure the trainer did 5 steps
+            self.assertTrue("pytorch_model.bin" in os.listdir(tmp_dir + "/checkpoint-2"))
+
     @require_peft
     def test_peft_sft_trainer(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -219,6 +219,17 @@ class SFTTrainer(Trainer):
             preprocess_logits_for_metrics=preprocess_logits_for_metrics,
         )
 
+        if self.args.max_steps > 0 and packing:
+            warnings.warn(
+                "You passed `packing=True` to the SFTTrainer, and you are training your model with `max_steps` strategy. Will force-set `infinite` argument of the packed dataset to `True` "
+            )
+            self.train_dataset.infinite = True
+        elif self.args.max_steps == -1 and packing:
+            warnings.warn(
+                "You passed `packing=False` to the SFTTrainer, and you are training your model with `epochs` strategy. Will force-set `infinite` argument of the packed dataset to `False` "
+            )
+            self.train_dataset.infinite = False
+
     def _prepare_dataset(
         self,
         dataset,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -225,9 +225,6 @@ class SFTTrainer(Trainer):
             )
             self.train_dataset.infinite = True
         elif self.args.max_steps == -1 and packing:
-            warnings.warn(
-                "You passed `packing=False` to the SFTTrainer, and you are training your model with `epochs` strategy. Will force-set `infinite` argument of the packed dataset to `False` "
-            )
             self.train_dataset.infinite = False
 
     def _prepare_dataset(

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -244,6 +244,7 @@ class ConstantLengthDataset(IterableDataset):
                 except StopIteration:
                     if self.infinite:
                         iterator = iter(self.dataset)
+                        warnings.warn("The dataset reached end. The iterator is reset")
                     else:
                         more_examples = False
                         break


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/lvwerra/trl/issues/450 

As reported in that issue, there is an inconsistent behaviour when using `packing=True` and the number of iterations showed in the logs of training. In fact, the inconsistency comes from the fact that in the packed case, sequences are packed all together on the fly until `max_seq_length` is reached, leading to reducing the number of total expected samples.

The fix is to force-set the `infinite` argument to `True` if a user explicity decides to train a model with `max_steps` strategy but properly warn them that the argument has been overriden and warn the user when the dataset is moved to the next iteration.

In the case of epochs training strategy, we should force-set infinite argument to False, otherwise the training will run forever.

Added also nice CI tests to make sure that this behavior will stay consistent in future commits.  Added also a line in the documentation.

cc @lvwerra @vwxyzjn 