### PR TITLE
Fix google colab issue

### DIFF
--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -171,7 +171,7 @@ class PPOConfig(object):
                         os.environ["WANDB_TAGS"] = ",".join([existing_wandb_tag, wandb_tag])
                     else:
                         os.environ["WANDB_TAGS"] = wandb_tag
-                logging.info(f"the following tags will be used for wandb logging: {os.environ['WANDB_TAGS']}")
+                    logging.info(f"the following tags will be used for wandb logging: {os.environ['WANDB_TAGS']}")
             except ImportError:
                 raise ImportError(
                     "Please install wandb to use wandb logging. You can do this by running `pip install wandb`."


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue users can encounter when initializing a PPOConfig on a google colab instance
If the autotag function fails, it returns an empty string, therefore `os.environ['WANDB_TAGS']` gets never populated leading to a keyerror in the logging process. 
This PR fixes it by adding the correct indentation

cc @lvwerra @vwxyzjn 
