### PR TITLE
[`CI`] Fix CI RM

### DIFF
--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -122,9 +122,9 @@ class RewardTrainerTester(unittest.TestCase):
             training_args = TrainingArguments(
                 output_dir=tmp_dir,
                 per_device_train_batch_size=2,
-                max_steps=3,
+                max_steps=6,
                 remove_unused_columns=False,
-                gradient_accumulation_steps=4,
+                gradient_accumulation_steps=2,
                 learning_rate=9e-1,
                 evaluation_strategy="steps",
             )


### PR DESCRIPTION
Currently a CI is failing (weird that it was not failing in the previous PRs - probably a recent release introduced a silent bug?)

The fix seems to simply correct the `gradient_accumulation steps` value. In fact putting `gradient_accumulation_steps > max_steps ` will lead to gradients that gets never updated

Related: https://github.com/lvwerra/trl/pull/416

Let's see if this fixes it 🤞 

cc @lvwerra 