### PR TITLE
Adds some options to stabilize the KL penalty

### DIFF
--- a/examples/sentiment/scripts/gpt2-sentiment.py
+++ b/examples/sentiment/scripts/gpt2-sentiment.py
@@ -67,6 +67,10 @@ class ScriptArguments:
     )
     early_stopping: Optional[bool] = field(default=False, metadata={"help": "whether to early stop"})
     target_kl: Optional[float] = field(default=6, metadata={"help": "kl target for early stopping"})
+    kl_penalty: Optional[str] = field(
+        default="kl",
+        metadata={"help": "kl penalty. Options: 'kl', 'abs', 'mse'}"},
+    )
 
 
 parser = HfArgumentParser(ScriptArguments)
@@ -81,6 +85,7 @@ config = PPOConfig(
     gradient_accumulation_steps=script_args.gradient_accumulation_steps,
     early_stopping=script_args.early_stopping,
     target_kl=script_args.target_kl,
+    kl_penalty=script_args.kl_penalty,
 )
 
 

--- a/examples/sentiment/scripts/gpt2-sentiment.py
+++ b/examples/sentiment/scripts/gpt2-sentiment.py
@@ -71,6 +71,7 @@ class ScriptArguments:
         default="kl",
         metadata={"help": "kl penalty. Options: 'kl', 'abs', 'mse'}"},
     )
+    seed: Optional[int] = field(default=0, metadata={"help": "the random seed"})
 
 
 parser = HfArgumentParser(ScriptArguments)
@@ -86,6 +87,7 @@ config = PPOConfig(
     early_stopping=script_args.early_stopping,
     target_kl=script_args.target_kl,
     kl_penalty=script_args.kl_penalty,
+    seed=script_args.seed,
 )
 
 

--- a/examples/sentiment/scripts/gpt2-sentiment.py
+++ b/examples/sentiment/scripts/gpt2-sentiment.py
@@ -69,7 +69,9 @@ class ScriptArguments:
     target_kl: Optional[float] = field(default=6, metadata={"help": "kl target for early stopping"})
     kl_penalty: Optional[str] = field(
         default="kl",
-        metadata={"help": "kl penalty. Options: 'kl', 'abs', 'mse'}"},
+        metadata={
+            "help": "kl penalty options: 'kl': model_logp - ref_logp,  'abs': abs(kl) and 'mse': mean squared error mse(kl)."
+        },
     )
     seed: Optional[int] = field(default=0, metadata={"help": "the random seed"})
 

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -692,8 +692,9 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
+        
         expected_output = torch.Tensor([[0.1000, -0.1000, 0.1000], [-0.1000, 0.1000, -0.2000]])
-        self.assertTrue(torch.equal(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
+        self.assertTrue(torch.allclose(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
 
         self.ppo_config.kl_penalty = "abs"
         ppo_trainer = PPOTrainer(
@@ -703,9 +704,9 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
+        
         expected_output = torch.Tensor([[0.1000, 0.1000, 0.1000], [0.1000, 0.1000, 0.2000]])
-
-        self.assertTrue(torch.equal(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
+        self.assertTrue(torch.allclose(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
 
         self.ppo_config.kl_penalty = "mse"
         ppo_trainer = PPOTrainer(
@@ -717,8 +718,7 @@ class PPOTrainerTester(unittest.TestCase):
         )
 
         expected_output = torch.Tensor([[0.0050, 0.0050, 0.0050], [0.0050, 0.0050, 0.0200]])
-
-        self.assertTrue(torch.equal(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
+        self.assertTrue(torch.allclose(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
 
     @require_peft
     @mark.peft_test

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -692,7 +692,7 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
-        
+
         expected_output = torch.Tensor([[0.1000, -0.1000, 0.1000], [-0.1000, 0.1000, -0.2000]])
         self.assertTrue(torch.allclose(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
 
@@ -704,7 +704,7 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
-        
+
         expected_output = torch.Tensor([[0.1000, 0.1000, 0.1000], [0.1000, 0.1000, 0.2000]])
         self.assertTrue(torch.allclose(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
 

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -681,11 +681,10 @@ class PPOTrainerTester(unittest.TestCase):
 
     def test_ppo_trainer_kl_penalty(self):
         dummy_dataset = self._init_dummy_dataset()
-        
-        log_probs = torch.Tensor([[0.5,0.2,0.1],[0.6,0.2,0.1]])
-        ref_log_probs = torch.Tensor([[0.4,0.3,0.0],[0.7,0.1,0.3]])
-        
-        
+
+        log_probs = torch.Tensor([[0.5, 0.2, 0.1], [0.6, 0.2, 0.1]])
+        ref_log_probs = torch.Tensor([[0.4, 0.3, 0.0], [0.7, 0.1, 0.3]])
+
         ppo_trainer = PPOTrainer(
             config=self.ppo_config,
             model=self.gpt2_model,
@@ -693,11 +692,9 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
-        expected_output = torch.Tensor([[ 0.1000, -0.1000,  0.1000],
-        [-0.1000,  0.1000, -0.2000]])
+        expected_output = torch.Tensor([[0.1000, -0.1000, 0.1000], [-0.1000, 0.1000, -0.2000]])
         self.assertTrue(torch.equal(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
-        
-        
+
         self.ppo_config.kl_penalty = "abs"
         ppo_trainer = PPOTrainer(
             config=self.ppo_config,
@@ -706,11 +703,10 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
-        expected_output = torch.Tensor([[ 0.1000, 0.1000,  0.1000],
-        [0.1000,  0.1000, 0.2000]])
+        expected_output = torch.Tensor([[0.1000, 0.1000, 0.1000], [0.1000, 0.1000, 0.2000]])
 
         self.assertTrue(torch.equal(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
-        
+
         self.ppo_config.kl_penalty = "mse"
         ppo_trainer = PPOTrainer(
             config=self.ppo_config,
@@ -719,13 +715,10 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
-        
-        expected_output = torch.Tensor([[0.0050, 0.0050, 0.0050],
-        [0.0050, 0.0050, 0.0200]])
+
+        expected_output = torch.Tensor([[0.0050, 0.0050, 0.0050], [0.0050, 0.0050, 0.0200]])
 
         self.assertTrue(torch.equal(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
-        
-        
 
     @require_peft
     @mark.peft_test

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -679,6 +679,54 @@ class PPOTrainerTester(unittest.TestCase):
                 f"Parameter {name} has a gradient larger than max_grad_norm",
             )
 
+    def test_ppo_trainer_kl_penalty(self):
+        dummy_dataset = self._init_dummy_dataset()
+        
+        log_probs = torch.Tensor([[0.5,0.2,0.1],[0.6,0.2,0.1]])
+        ref_log_probs = torch.Tensor([[0.4,0.3,0.0],[0.7,0.1,0.3]])
+        
+        
+        ppo_trainer = PPOTrainer(
+            config=self.ppo_config,
+            model=self.gpt2_model,
+            ref_model=None,
+            tokenizer=self.gpt2_tokenizer,
+            dataset=dummy_dataset,
+        )
+        expected_output = torch.Tensor([[ 0.1000, -0.1000,  0.1000],
+        [-0.1000,  0.1000, -0.2000]])
+        self.assertTrue(torch.equal(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
+        
+        
+        self.ppo_config.kl_penalty = "abs"
+        ppo_trainer = PPOTrainer(
+            config=self.ppo_config,
+            model=self.gpt2_model,
+            ref_model=None,
+            tokenizer=self.gpt2_tokenizer,
+            dataset=dummy_dataset,
+        )
+        expected_output = torch.Tensor([[ 0.1000, 0.1000,  0.1000],
+        [0.1000,  0.1000, 0.2000]])
+
+        self.assertTrue(torch.equal(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
+        
+        self.ppo_config.kl_penalty = "mse"
+        ppo_trainer = PPOTrainer(
+            config=self.ppo_config,
+            model=self.gpt2_model,
+            ref_model=None,
+            tokenizer=self.gpt2_tokenizer,
+            dataset=dummy_dataset,
+        )
+        
+        expected_output = torch.Tensor([[0.0050, 0.0050, 0.0050],
+        [0.0050, 0.0050, 0.0200]])
+
+        self.assertTrue(torch.equal(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
+        
+        
+
     @require_peft
     @mark.peft_test
     def test_peft_model_ppo_trainer(self):

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -77,6 +77,10 @@ class PPOConfig(object):
         default=0.2,
         metadata={"help": "Initial KL penalty coefficient (used for adaptive and linear control)"},
     )
+    kl_penalty: Optional[str] = field(
+        default="kl",
+        metadata={"help": "kl penalty. Options: 'kl', 'abs', 'mse'}"},
+    )
     target: Optional[float] = field(default=6, metadata={"help": "Target KL value for adaptive KL control"})
     horizon: Optional[float] = field(default=10000, metadata={"help": "Horizon for adaptive KL control"})
     gamma: Optional[float] = field(default=1, metadata={"help": "Gamma parameter for advantage calculation"})
@@ -178,6 +182,7 @@ class PPOConfig(object):
                 )
 
         self.total_ppo_epochs = int(np.ceil(self.steps / self.batch_size))
+        assert self.kl_penalty in ["kl", "abs", "mse"]
 
     def to_dict(self):
         output_dict = {}

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -79,7 +79,9 @@ class PPOConfig(object):
     )
     kl_penalty: Optional[str] = field(
         default="kl",
-        metadata={"help": "kl penalty. Options: 'kl', 'abs', 'mse'}"},
+        metadata={
+            "help": "kl penalty options: 'kl': model_logp - ref_logp,  'abs': abs(kl) and 'mse': mean squared error mse(kl)."
+        },
     )
     target: Optional[float] = field(default=6, metadata={"help": "Target KL value for adaptive KL control"})
     horizon: Optional[float] = field(default=10000, metadata={"help": "Horizon for adaptive KL control"})

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -982,18 +982,17 @@ class PPOTrainer(BaseTrainer):
             rewards.append(reward)
         return torch.stack(rewards), torch.stack(non_score_rewards)
 
-    def _kl_penalty(self, logprob: torch.FloatTensor, ref_logprob: torch.FloatTensor)-> torch.FloatTensor:
+    def _kl_penalty(self, logprob: torch.FloatTensor, ref_logprob: torch.FloatTensor) -> torch.FloatTensor:
         if self.ppo_config.kl_penalty == "kl":
-            return  logprob - ref_logprob
-        
+            return logprob - ref_logprob
+
         if self.ppo_config.kl_penalty == "abs":
             return (logprob - ref_logprob).abs()
-        
-        if self.ppo_config.kl_penalty == "mse":
-            return 0.5*(logprob - ref_logprob).square()
-        
-        raise NotImplementedError
 
+        if self.ppo_config.kl_penalty == "mse":
+            return 0.5 * (logprob - ref_logprob).square()
+
+        raise NotImplementedError
 
     def loss(
         self,

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -971,7 +971,7 @@ class PPOTrainer(BaseTrainer):
         rewards, non_score_rewards = [], []
         for score, logprob, ref_logprob, mask in zip(scores, logprobs, ref_logprobs, masks):
             # compute KL penalty (from difference in logprobs)
-            kl = logprob - ref_logprob
+            kl = self._kl_penalty(logprob, ref_logprob)
             non_score_reward = -self.kl_ctl.value * kl
             non_score_rewards.append(non_score_reward)
             reward = non_score_reward.clone()
@@ -981,6 +981,19 @@ class PPOTrainer(BaseTrainer):
             reward[last_non_masked_index] += score
             rewards.append(reward)
         return torch.stack(rewards), torch.stack(non_score_rewards)
+
+    def _kl_penalty(self, logprob: torch.FloatTensor, ref_logprob: torch.FloatTensor)-> torch.FloatTensor:
+        if self.ppo_config.kl_penalty == "kl":
+            return  logprob - ref_logprob
+        
+        if self.ppo_config.kl_penalty == "abs":
+            return (logprob - ref_logprob).abs()
+        
+        if self.ppo_config.kl_penalty == "mse":
+            return 0.5*(logprob - ref_logprob).square()
+        
+        raise NotImplementedError
+
 
     def loss(
         self,

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -983,13 +983,13 @@ class PPOTrainer(BaseTrainer):
         return torch.stack(rewards), torch.stack(non_score_rewards)
 
     def _kl_penalty(self, logprob: torch.FloatTensor, ref_logprob: torch.FloatTensor) -> torch.FloatTensor:
-        if self.ppo_config.kl_penalty == "kl":
+        if self.config.kl_penalty == "kl":
             return logprob - ref_logprob
 
-        if self.ppo_config.kl_penalty == "abs":
+        if self.config.kl_penalty == "abs":
             return (logprob - ref_logprob).abs()
 
-        if self.ppo_config.kl_penalty == "mse":
+        if self.config.kl_penalty == "mse":
             return 0.5 * (logprob - ref_logprob).square()
 
         raise NotImplementedError


### PR DESCRIPTION
This PR adds some options to stabilize the KL penalty, abs and MSE of KL estimates as detailed [here](http://joschu.net/blog/kl-approx.html).

This PR has a similar motivation of [PR#423](https://github.com/lvwerra/trl/pull/423) but here we focus on the KL penalty calculation between the base model and policy, whereas the other PR is the KL between the policy used for generation and the latest version of the policy after k PPO steps.

I have launched the gpt-sentiment example in three configurations:
- [default](https://wandb.ai/edbeeching/trl/runs/86cnr8py?workspace=user-edbeeching)
- [abs kl](https://wandb.ai/edbeeching/trl/runs/zaejlw0r?workspace=user-edbeeching)
- [mse kl](https://wandb.ai/edbeeching/trl/runs/ptykchil?workspace=user-edbeeching)

![image](https://github.com/lvwerra/trl/assets/7275864/9c63856a-dfd8-4f87-b215-2d9bd297dd73)

**Convergence over 10 seeds - default:**
![image](https://github.com/lvwerra/trl/assets/7275864/585b529f-e524-4baa-9eb5-4c442ed96315)

**Convergence over 10 seeds - abs kl:**
![image](https://github.com/lvwerra/trl/assets/7275864/365ad433-d021-41fa-abcb-d919f436be3a)

**Convergence over 10 seeds - mse kl:**
![image](https://github.com/lvwerra/trl/assets/7275864/8329225e-3a65-42c3-81ec-6fc98eab7fe7)



