### PR TITLE
add ratio threshold to avoid spikes

### DIFF
--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -150,6 +150,9 @@ class PPOConfig(object):
         default=1,
         metadata={"help": "Number of steps between comparison of the current reward with the best seen so far"},
     )
+    ratio_threshold: Optional[float] = field(
+        default=10.0, metadata={"help": "Skip mini-batches with high PPO ratios that can cause loss spikes"}
+    )
 
     def __post_init__(self):
         if self.forward_batch_size is not None:

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -1045,6 +1045,15 @@ class PPOTrainer(BaseTrainer):
 
         loss = pg_loss + self.config.vf_coef * vf_loss
 
+        avg_ratio = masked_mean(ratio, mask).item()
+        if avg_ratio > self.config.ratio_threshold:
+            warnings.warn(
+                f"The average ratio of batch ({avg_ratio:.2f}) exceeds threshold {self.config.ratio_threshold:.2f}. Skipping batch."
+            )
+            pg_loss = pg_loss * 0.0
+            vf_loss = vf_loss * 0.0
+            loss = loss * 0.0
+
         entropy = masked_mean(entropy_from_logits(logits), mask)
         approxkl = 0.5 * masked_mean((logprobs - old_logprobs) ** 2, mask)
         policykl = masked_mean(old_logprobs - logprobs, mask)


### PR DESCRIPTION
Investigating issue #101 further we found that they are usually caused by abnormally high ratios in the PPO loss. This adds a threshold to skip those batches. See below for a seed that had a spike before and after the fix:

![Screenshot 2023-07-03 at 17 21 03](https://github.com/lvwerra/trl/assets/8264887/9bcd8f12-775b-4fe9-816f-9712fa903dcf)
![Screenshot 2023-07-03 at 17 20 39](https://github.com/lvwerra/trl/assets/8264887/72569b80-726f-4242-8e8e-25e2f4e0a252)
