### PR TITLE
FIX: contributing guidelines command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,9 @@ Then before submitting your PR make sure the code quality follows the standards.
 make precommit
 ```
 
+Make sure to install `pre-commit` before running the command:
+```bash
+pip install pre-commit
 ## Do you want to contribute to the documentation?
 
 * Docs are in the `docs/` folder and can be updated there.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,8 @@ make precommit
 Make sure to install `pre-commit` before running the command:
 ```bash
 pip install pre-commit
+```
+
 ## Do you want to contribute to the documentation?
 
 * Docs are in the `docs/` folder and can be updated there.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ make test
 Then before submitting your PR make sure the code quality follows the standards. You can run the following command to format:
 
 ```bash
-make commit
+make precommit
 ```
 
 ## Do you want to contribute to the documentation?


### PR DESCRIPTION
The contributing guideline mentions `make commit` but this should be `make precommit` as per the Makefile.