### PR TITLE
fix typo in reward_modeling.py

### DIFF
--- a/examples/stack_llama/scripts/reward_modeling.py
+++ b/examples/stack_llama/scripts/reward_modeling.py
@@ -41,7 +41,7 @@ class ScriptArguments:
     per_device_eval_batch_size: Optional[int] = field(default=1)
     gradient_accumulation_steps: Optional[int] = field(default=1)
     learning_rate: Optional[float] = field(default=2e-5)
-    weight_decay: Optional[int] = field(default=0.001)
+    weight_decay: Optional[float] = field(default=0.001)
     model_name: Optional[str] = field(
         default="gpt2",
         metadata={


### PR DESCRIPTION
Fix `weight_decay` Field Type

Changed the type of `weight_decay` from `Optional[int]` to `Optional[float]`.