### PR TITLE
[`PPOTrainer`] Add prompt tuning support on TRL

### DIFF
--- a/docs/source/lora_tuning_peft.mdx
+++ b/docs/source/lora_tuning_peft.mdx
@@ -1,6 +1,6 @@
 # Examples of using peft with trl to finetune 8-bit models with Low Rank Adaption (LoRA)
 
-The notebooks and scripts in this examples show how to use Low Rank Adaptation (LoRA) to fine-tune models in a memory efficient manner.
+The notebooks and scripts in this examples show how to use Low Rank Adaptation (LoRA) to fine-tune models in a memory efficient manner. Most of PEFT methods supported in peft library but note that some PEFT methods such as Prompt tuning are not supported.
 For more information on LoRA, see the [original paper](https://arxiv.org/abs/2106.09685).
 
 Here's an overview of the `peft`-enabled notebooks and scripts in the [trl repository](https://github.com/lvwerra/trl/tree/main/examples):

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -872,6 +872,66 @@ class PPOTrainerTester(unittest.TestCase):
                 else:
                     self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
 
+    @require_peft
+    @mark.peft_test
+    def test_peft_model_ppo_trainer_prompt_tuning(self):
+        from peft import PromptTuningConfig, TaskType, get_peft_model
+        from transformers import AutoModelForCausalLM
+
+        pt_config = PromptTuningConfig(
+            task_type=TaskType.CAUSAL_LM,
+            num_virtual_tokens=10,
+            tokenizer_name_or_path=self.model_id,
+            inference_mode=False,
+            token_dim=32,
+        )
+        gpt2_model = AutoModelForCausalLM.from_pretrained(self.model_id)
+
+        # this line is very important
+        def make_inputs_require_grad(module, input, output):
+            output.requires_grad_(True)
+
+        gpt2_model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
+
+        peft_model = get_peft_model(gpt2_model, pt_config)
+        model = AutoModelForCausalLMWithValueHead.from_pretrained(peft_model)
+
+        dummy_dataset = self._init_dummy_dataset()
+        self.ppo_config.batch_size = 2
+        self.ppo_config.mini_batch_size = 1
+
+        ppo_trainer = PPOTrainer(
+            config=self.ppo_config,
+            model=model,
+            ref_model=None,
+            tokenizer=self.gpt2_tokenizer,
+            dataset=dummy_dataset,
+        )
+
+        self.assertTrue(ppo_trainer.ref_model is None)
+
+        dummy_dataloader = ppo_trainer.dataloader
+
+        # train model with ppo
+        for query_tensor, response_tensor in dummy_dataloader:
+            # define a reward for response
+            # (this could be any reward such as human feedback or output from another model)
+            reward = [torch.tensor(1.0), torch.tensor(0.0)]
+            # train model by running a step twice
+            _ = ppo_trainer.step([q for q in query_tensor], [r for r in response_tensor], reward)
+
+            ppo_trainer.model.train()
+            ppo_trainer.model.gradient_checkpointing_enable()
+            _ = ppo_trainer.step([q for q in query_tensor], [r for r in response_tensor], reward)
+            break
+
+        # check gradients
+        for name, param in model.named_parameters():
+            if "prompt_encoder" in name or "v_head" in name:
+                self.assertTrue(param.grad is not None, f"Parameter {name} has a no gradient")
+            else:
+                self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
+
     @unittest.skip("Fix by either patching `whomai()` to work in the staging endpoint or use a dummy prod user.")
     def test_push_to_hub(self):
         REPO_NAME = "test-ppo-trainer"

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -872,67 +872,6 @@ class PPOTrainerTester(unittest.TestCase):
                 else:
                     self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
 
-    @require_peft
-    @mark.peft_test
-    def test_peft_model_ppo_trainer_prompt_tuning(self):
-        from peft import PromptTuningConfig, TaskType, get_peft_model
-        from transformers import AutoModelForCausalLM
-
-        pt_config = PromptTuningConfig(
-            task_type=TaskType.CAUSAL_LM,
-            num_virtual_tokens=10,
-            tokenizer_name_or_path=self.model_id,
-            inference_mode=False,
-            token_dim=32,
-            encoder_hidden_size=32,
-        )
-        gpt2_model = AutoModelForCausalLM.from_pretrained(self.model_id)
-
-        # this line is very important
-        def make_inputs_require_grad(module, input, output):
-            output.requires_grad_(True)
-
-        gpt2_model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
-
-        peft_model = get_peft_model(gpt2_model, pt_config)
-        model = AutoModelForCausalLMWithValueHead.from_pretrained(peft_model)
-
-        dummy_dataset = self._init_dummy_dataset()
-        self.ppo_config.batch_size = 2
-        self.ppo_config.mini_batch_size = 1
-
-        ppo_trainer = PPOTrainer(
-            config=self.ppo_config,
-            model=model,
-            ref_model=None,
-            tokenizer=self.gpt2_tokenizer,
-            dataset=dummy_dataset,
-        )
-
-        self.assertTrue(ppo_trainer.ref_model is None)
-
-        dummy_dataloader = ppo_trainer.dataloader
-
-        # train model with ppo
-        for query_tensor, response_tensor in dummy_dataloader:
-            # define a reward for response
-            # (this could be any reward such as human feedback or output from another model)
-            reward = [torch.tensor(1.0), torch.tensor(0.0)]
-            # train model by running a step twice
-            _ = ppo_trainer.step([q for q in query_tensor], [r for r in response_tensor], reward)
-
-            ppo_trainer.model.train()
-            ppo_trainer.model.gradient_checkpointing_enable()
-            _ = ppo_trainer.step([q for q in query_tensor], [r for r in response_tensor], reward)
-            break
-
-        # check gradients
-        for name, param in model.named_parameters():
-            if "prompt_encoder" in name or "v_head" in name:
-                self.assertTrue(param.grad is not None, f"Parameter {name} has a no gradient")
-            else:
-                self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
-
     @unittest.skip("Fix by either patching `whomai()` to work in the staging endpoint or use a dummy prod user.")
     def test_push_to_hub(self):
         REPO_NAME = "test-ppo-trainer"

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -884,6 +884,7 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer_name_or_path=self.model_id,
             inference_mode=False,
             token_dim=32,
+            encoder_hidden_size=32,
         )
         gpt2_model = AutoModelForCausalLM.from_pretrained(self.model_id)
 

--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -128,8 +128,6 @@ class PreTrainedModelWrapper(nn.Module):
             )
 
         is_peft_model = False
-        is_using_prompt_learning = False
-        prompt_learning_num_virtual_tokens = None
 
         current_device = cls._get_current_device()
         if isinstance(pretrained_model_name_or_path, str):
@@ -225,9 +223,11 @@ class PreTrainedModelWrapper(nn.Module):
         if is_peft_available():
             if isinstance(pretrained_model, PeftModel):
                 is_peft_model = True
-                if isinstance(pretrained_model.active_peft_config, PromptLearningConfig):
-                    is_using_prompt_learning = True
-                    prompt_learning_num_virtual_tokens = pretrained_model.active_peft_config.num_virtual_tokens
+                # for backward compatibility
+                if hasattr(pretrained_model, "active_peft_config") and isinstance(
+                    pretrained_model.active_peft_config, PromptLearningConfig
+                ):
+                    raise ValueError("PromptLearningConfig is not supported for PPO training.")
         # Then, create the full model by instantiating the wrapper class
         model = cls(pretrained_model, **trl_model_args)
 
@@ -281,8 +281,6 @@ class PreTrainedModelWrapper(nn.Module):
             state_dict = pretrained_model_name_or_path.state_dict()
 
         model.is_peft_model = is_peft_model
-        model.is_using_prompt_learning = is_using_prompt_learning
-        model.prompt_learning_num_virtual_tokens = prompt_learning_num_virtual_tokens
 
         model.current_device = current_device
 

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -879,9 +879,6 @@ class PPOTrainer(BaseTrainer):
             masks = torch.zeros_like(attention_mask)
             masks[:, :-1] = attention_mask[:, 1:]
 
-            prompt_learning_processed_masks = []
-            prompt_learning_processed_logprobs = []
-
             for j in range(fbs):
                 if self.is_encoder_decoder:
                     # Decoder sentence starts always in the index 1 after padding in the Enc-Dec Models
@@ -895,17 +892,6 @@ class PPOTrainer(BaseTrainer):
 
                 masks[j, :start] = 0
                 masks[j, end:] = 0
-
-                if model.is_using_prompt_learning:
-                    num_new_tokens = model.prompt_learning_num_virtual_tokens
-                    prompt_mask = torch.ones_like(values[j, :num_new_tokens])
-
-                    prompt_learning_processed_masks.append(torch.cat([prompt_mask, masks[j]]))
-                    prompt_learning_processed_logprobs.append(torch.cat([torch.zeros_like(prompt_mask), logprobs[j]]))
-
-            if model.is_using_prompt_learning:
-                masks = torch.stack(prompt_learning_processed_masks)
-                logprobs = torch.stack(prompt_learning_processed_logprobs)
 
             if return_logits:
                 all_logits.append(logits)
@@ -1087,10 +1073,9 @@ class PPOTrainer(BaseTrainer):
 
         entropy = masked_mean(entropy_from_logits(logits), mask)
 
-        logprob_diff = old_logprobs - logprobs
+        approxkl = 0.5 * masked_mean((logprobs - old_logprobs) ** 2, mask)
+        policykl = masked_mean(old_logprobs - logprobs, mask)
 
-        approxkl = 0.5 * masked_mean(logprob_diff**2, mask)
-        policykl = masked_mean(logprob_diff, mask)
         return_mean, return_var = masked_mean(returns, mask), masked_var(returns, mask)
         value_mean, value_var = masked_mean(values, mask), masked_var(values, mask)
 


### PR DESCRIPTION
Fixes https://github.com/lvwerra/trl/issues/490 

Prompt tunning appends new tokens in the beginning of the generated sentence and make the new vocabulary that is used to generate these tokens trainable. 
Before this PR that PEFT method was not supported out of the box. I propose a v1 to integrate prompt tuning into TRL.

Might be also related to https://github.com/lvwerra/trl/issues/470 

Added also a nice test that fails on main and does not fail on this branch

In my opinion we should zero-out the logits that corresponds to these new tokens as it is not possible to compute reference logits on these tokens, however we shouldn't mask out these tokens in the PPO step

cc @lvwerra 