### PR TITLE
[`PPOTrainer`] Add prefix tuning support

### DIFF
--- a/trl/models/modeling_value_head.py
+++ b/trl/models/modeling_value_head.py
@@ -158,9 +158,11 @@ class AutoModelForCausalLMWithValueHead(PreTrainedModelWrapper):
         """
         kwargs["output_hidden_states"] = True  # this had already been set in the LORA / PEFT examples
 
+        if self.pretrained_model.active_peft_config.peft_type != "PREFIX_TUNING":
+            kwargs["past_key_values"] = past_key_values
+
         base_model_output = self.pretrained_model(
             input_ids=input_ids,
-            past_key_values=past_key_values,
             attention_mask=attention_mask,
             **kwargs,
         )
@@ -392,9 +394,11 @@ class AutoModelForSeq2SeqLMWithValueHead(PreTrainedModelWrapper):
         attention_mask=None,
         **kwargs,
     ):
+        if self.pretrained_model.active_peft_config.peft_type != "PREFIX_TUNING":
+            kwargs["past_key_values"] = past_key_values
+
         base_model_output = self.pretrained_model(
             input_ids=input_ids,
-            past_key_values=past_key_values,
             attention_mask=attention_mask,
             output_hidden_states=True,  # We force the model to output hidden states
             **kwargs,

--- a/trl/models/modeling_value_head.py
+++ b/trl/models/modeling_value_head.py
@@ -158,7 +158,7 @@ class AutoModelForCausalLMWithValueHead(PreTrainedModelWrapper):
         """
         kwargs["output_hidden_states"] = True  # this had already been set in the LORA / PEFT examples
 
-        if self.pretrained_model.active_peft_config.peft_type != "PREFIX_TUNING":
+        if self.is_peft_model and self.pretrained_model.active_peft_config.peft_type != "PREFIX_TUNING":
             kwargs["past_key_values"] = past_key_values
 
         base_model_output = self.pretrained_model(
@@ -394,7 +394,7 @@ class AutoModelForSeq2SeqLMWithValueHead(PreTrainedModelWrapper):
         attention_mask=None,
         **kwargs,
     ):
-        if self.pretrained_model.active_peft_config.peft_type != "PREFIX_TUNING":
+        if self.is_peft_model and self.pretrained_model.active_peft_config.peft_type != "PREFIX_TUNING":
             kwargs["past_key_values"] = past_key_values
 
         base_model_output = self.pretrained_model(

--- a/trl/models/modeling_value_head.py
+++ b/trl/models/modeling_value_head.py
@@ -157,9 +157,10 @@ class AutoModelForCausalLMWithValueHead(PreTrainedModelWrapper):
                 Additional keyword arguments, that are passed to the wrapped model.
         """
         kwargs["output_hidden_states"] = True  # this had already been set in the LORA / PEFT examples
+        kwargs["past_key_values"] = past_key_values
 
-        if self.is_peft_model and self.pretrained_model.active_peft_config.peft_type != "PREFIX_TUNING":
-            kwargs["past_key_values"] = past_key_values
+        if self.is_peft_model and self.pretrained_model.active_peft_config.peft_type == "PREFIX_TUNING":
+            kwargs.pop("past_key_values")
 
         base_model_output = self.pretrained_model(
             input_ids=input_ids,
@@ -394,8 +395,9 @@ class AutoModelForSeq2SeqLMWithValueHead(PreTrainedModelWrapper):
         attention_mask=None,
         **kwargs,
     ):
-        if self.is_peft_model and self.pretrained_model.active_peft_config.peft_type != "PREFIX_TUNING":
-            kwargs["past_key_values"] = past_key_values
+        kwargs["past_key_values"] = past_key_values
+        if self.is_peft_model and self.pretrained_model.active_peft_config.peft_type == "PREFIX_TUNING":
+            kwargs.pop("past_key_values")
 
         base_model_output = self.pretrained_model(
             input_ids=input_ids,


### PR DESCRIPTION
Fixes https://github.com/lvwerra/trl/issues/470

This PR correctly deals with prefix tuning when using PEFT + TRL, to reproduce:

```python
import peft
from peft import PrefixTuningConfig, TaskType, get_peft_model

import torch
from datasets import load_dataset
from tqdm import tqdm
from transformers import AutoTokenizer, HfArgumentParser, pipeline, AutoModelForSeq2SeqLM

from trl import AutoModelForSeq2SeqLMWithValueHead, PPOConfig, PPOTrainer, set_seed
from trl.core import LengthSampler


tqdm.pandas()


config = PPOConfig(
    model_name='t5-base',  
    batch_size=16,
    mini_batch_size=4,
)

# We then define the arguments to pass to the sentiment analysis pipeline.
# We set `return_all_scores` to True to get the sentiment score for each token.
sent_kwargs = {"return_all_scores": True, "function_to_apply": "none", "batch_size": 16}


# Below is an example function to build the dataset. In our case, we use the IMDB dataset
# from the `datasets` library. One should customize this function to train the model on
# its own dataset.
def build_imdb_dataset(tokenizer, input_min_text_length=2, input_max_text_length=8):
    # load imdb with datasets
    ds = load_dataset("imdb", split="train")
    ds = ds.rename_columns({"text": "review"})
    ds = ds.filter(lambda x: len(x["review"]) > 200, batched=False)

    input_size = LengthSampler(input_min_text_length, input_max_text_length)

    def tokenize(sample):
        sample["input_ids"] = tokenizer.encode(sample["review"])[: input_size()] + [tokenizer.eos_token_id]
        sample["query"] = tokenizer.decode(sample["input_ids"])
        return sample

    ds = ds.map(tokenize, batched=False)
    ds.set_format(type="torch")
    return ds


def collater(data):
    return dict((key, [d[key] for d in data]) for key in data[0])


# set seed before initializing value head for deterministic eval
set_seed(config.seed)


## Initialise the model
model_name = 't5-base'
model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
peft_config = PrefixTuningConfig(task_type=TaskType.SEQ_2_SEQ_LM, inference_mode=False, num_virtual_tokens=25)
# peft_config = LoraConfig(task_type=TaskType.SEQ_2_SEQ_LM, inference_mode=False, r=14, lora_alpha=32, lora_dropout=0.1)
peft_model = get_peft_model(model, peft_config)
peft_model.print_trainable_parameters()

trl_model = AutoModelForSeq2SeqLMWithValueHead.from_pretrained(peft_model)
trl_reference_model = AutoModelForSeq2SeqLMWithValueHead.from_pretrained(peft_model)


# We retrieve the dataloader by calling the `build_dataset` function.
dataset = build_imdb_dataset(tokenizer)

query = tokenizer("I really liked this movie because", return_tensors="pt")["input_ids"]

generation_kwargs = {"top_k": 0.0, "top_p": 1.0, "do_sample": True, "eos_token_id": -1}


# We then build the PPOTrainer, passing the model, the reference model, the tokenizer
ppo_trainer = PPOTrainer(config, trl_model, trl_reference_model, tokenizer, dataset=dataset, data_collator=collater)

# We then build the sentiment analysis pipeline, passing the model name and the
# sentiment analysis pipeline arguments. Let's also make sure to set the device
# to the same device as the PPOTrainer.
device = ppo_trainer.accelerator.device
if ppo_trainer.accelerator.num_processes == 1:
    device = 0 if torch.cuda.is_available() else "cpu"  # to avoid a `pipeline` bug
sentiment_pipe = pipeline("sentiment-analysis", "lvwerra/distilbert-imdb", device=device)

# We then define the arguments to pass to the `generate` function. These arguments
# are passed to the `generate` function of the PPOTrainer, which is a wrapper around
# the `generate` function of the trained model.
output_min_length = 16
output_max_length = 32
output_length_sampler = LengthSampler(output_min_length, output_max_length)

for epoch, batch in tqdm(enumerate(ppo_trainer.dataloader)):
    query_tensors = batch["input_ids"]

    # Get response from t5
    response_tensors = ppo_trainer.generate(
        query_tensors, return_prompt=False, length_sampler=output_length_sampler, **generation_kwargs
    )
    batch["response"] = tokenizer.batch_decode([r[1:] for r in response_tensors])

    # Compute sentiment score
    texts = [q + r for q, r in zip(batch["query"], batch["response"])]
    pipe_outputs = sentiment_pipe(texts, **sent_kwargs)
    rewards = [torch.tensor(output[1]["score"]).to(device) for output in pipe_outputs]

    # Run PPO step
    stats = ppo_trainer.step(query_tensors, response_tensors, rewards)
    ppo_trainer.log_stats(stats, batch, rewards)
```

cc @lvwerra 