### PR TITLE
[`SFTTrainer`] Fix the sequence length check of `SFTTrainer`

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -270,9 +270,6 @@ class SFTTrainer(Trainer):
 
         # Inspired from: https://huggingface.co/learn/nlp-course/chapter7/6?fw=pt
         def tokenize(element):
-            input_batch = []
-            attention_masks = []
-
             outputs = tokenizer(
                 element[dataset_text_field] if not use_formatting_func else formatting_func(element),
                 truncation=True,
@@ -290,19 +287,7 @@ class SFTTrainer(Trainer):
                 else:
                     self._dataset_sanity_checked = True
 
-            for length, input_ids, attention_mask in zip(
-                outputs["length"], outputs["input_ids"], outputs["attention_mask"]
-            ):
-                if length == max_seq_len:
-                    input_batch.append(input_ids)
-                    attention_masks.append(attention_mask)
-
-            if len(input_batch) == 0:
-                # warn users
-                warnings.warn(
-                    f"Found 0 samples with a length of {max_seq_len}. You might want to decrease the `max_seq_len` argument."
-                )
-            return {"input_ids": input_batch, "attention_mask": attention_masks}
+            return {"input_ids": outputs["input_ids"], "attention_mask": outputs["attention_mask"]}
 
         tokenized_dataset = dataset.map(tokenize, batched=True, remove_columns=dataset.column_names)
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -273,10 +273,10 @@ class SFTTrainer(Trainer):
             outputs = tokenizer(
                 element[dataset_text_field] if not use_formatting_func else formatting_func(element),
                 truncation=True,
-                padding=True,
+                padding=False,
                 max_length=max_seq_len,
                 return_overflowing_tokens=False,
-                return_length=True,
+                return_length=False,
             )
 
             if use_formatting_func and not self._dataset_sanity_checked:


### PR DESCRIPTION
# What does this PR do? 

Fixes https://github.com/lvwerra/trl/issues/467
Replaces https://github.com/lvwerra/trl/pull/481

The original code lead to having examples that were filtered out by the previous check. This ultimately lead to having examples being ignored when processing the data. Probably a copy-pasta from: https://huggingface.co/learn/nlp-course/chapter7/6?fw=pt where I borrowed the original code

The fix is to remove completely that check

cc @lvwerra 