### PR TITLE
Reward trainer multi-gpu eval bug

### DIFF
--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -206,5 +206,6 @@ class RewardTrainer(Trainer):
         logits = torch.stack(logits).mean(dim=2).softmax(dim=0).T
 
         labels = torch.zeros(logits.shape[0])
+        labels = self._prepare_inputs(labels)
 
         return loss, logits, labels


### PR DESCRIPTION
Fixes #451 - "Tensors must be CUDA and dense" bug

This puts the label tensors onto the correct device when evaling with deepspeed.