### PR TITLE
Computes the KL penalty using the entire distribution

### DIFF
--- a/examples/scripts/sentiment_tuning.py
+++ b/examples/scripts/sentiment_tuning.py
@@ -51,7 +51,7 @@ class ScriptArguments:
     kl_penalty: Optional[str] = field(
         default="kl",
         metadata={
-            "help": "kl penalty options: 'kl': model_logp - ref_logp,  'abs': abs(kl) and 'mse': mean squared error mse(kl)."
+            "help": "kl penalty options: 'kl': model_logp - ref_logp,  'abs': abs(kl),  'mse': mean squared error mse(kl) and 'full': the actual kl for all tokens in the distribution"
         },
     )
     target_kl: Optional[float] = field(default=0.1, metadata={"help": "kl target for early stopping"})

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -719,13 +719,11 @@ class PPOTrainerTester(unittest.TestCase):
 
         expected_output = torch.Tensor([[0.0050, 0.0050, 0.0050], [0.0050, 0.0050, 0.0200]])
         self.assertTrue(torch.allclose(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
-        
-        
+
     def test_ppo_trainer_full_kl_penalty(self):
         # a few more extensive tests for the full kl option as it is more involved
         dummy_dataset = self._init_dummy_dataset()
-        
-       
+
         self.ppo_config.kl_penalty = "full"
         ppo_trainer = PPOTrainer(
             config=self.ppo_config,
@@ -734,70 +732,86 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
-        
+
         # Test on tensors for size B,S,T = (1,2,3)
         # test for when the two dists are the same
-        log_probs = torch.Tensor([   
+        log_probs = torch.Tensor(
             [
-                [0.1, 0.2, 0.7],
-                [0.3, 0.4, 0.3],
+                [
+                    [0.1, 0.2, 0.7],
+                    [0.3, 0.4, 0.3],
+                ]
             ]
-        ]).exp()
+        ).exp()
 
-        ref_log_probs = torch.Tensor([   
+        ref_log_probs = torch.Tensor(
             [
-                [0.1, 0.2, 0.7],
-                [0.3, 0.4, 0.3],
+                [
+                    [0.1, 0.2, 0.7],
+                    [0.3, 0.4, 0.3],
+                ]
             ]
-        ]).exp()
-        
-        expected_output = torch.Tensor([[0.0, 0.0]],)
+        ).exp()
+
+        expected_output = torch.Tensor(
+            [[0.0, 0.0]],
+        )
         output = ppo_trainer._kl_penalty(log_probs, ref_log_probs)
-        self.assertTrue(output.shape == (1,2))
+        self.assertTrue(output.shape == (1, 2))
         self.assertTrue(torch.allclose(output, expected_output))
-        
-        # test for when the two dists are almost not overlapping
-        log_probs = torch.Tensor([   
-            [
-                [0.98, 0.01, 0.01],
-                [0.01, 0.98, 0.01],
-            ]
-        ]).log()
 
-        ref_log_probs = torch.Tensor([   
+        # test for when the two dists are almost not overlapping
+        log_probs = torch.Tensor(
             [
-                [0.01,0.01,0.98],
-                [0.01,0.01,0.98],
+                [
+                    [0.98, 0.01, 0.01],
+                    [0.01, 0.98, 0.01],
+                ]
             ]
-        ]).log()
-        
-        expected_output = torch.Tensor([[4.4474, 4.4474]],)
+        ).log()
+
+        ref_log_probs = torch.Tensor(
+            [
+                [
+                    [0.01, 0.01, 0.98],
+                    [0.01, 0.01, 0.98],
+                ]
+            ]
+        ).log()
+
+        expected_output = torch.Tensor(
+            [[4.4474, 4.4474]],
+        )
         output = ppo_trainer._kl_penalty(log_probs, ref_log_probs)
-        self.assertTrue(output.shape == (1,2))
+        self.assertTrue(output.shape == (1, 2))
         self.assertTrue(torch.allclose(output, expected_output))
-        
-        # test for when the two dists are almost not overlapping
-        log_probs = torch.Tensor([   
-            [
-                [0.49, 0.02, 0.49],
-                [0.49, 0.02, 0.49],
-            ]
-        ]).log()
 
-        ref_log_probs = torch.Tensor([   
+        # test for when the two dists are almost not overlapping
+        log_probs = torch.Tensor(
             [
-                [0.01, 0.98, 0.01],
-                [0.49, 0.02, 0.49],
+                [
+                    [0.49, 0.02, 0.49],
+                    [0.49, 0.02, 0.49],
+                ]
             ]
-        ]).log()
-        
-        expected_output = torch.Tensor([[3.7361, 0.0]],)
+        ).log()
+
+        ref_log_probs = torch.Tensor(
+            [
+                [
+                    [0.01, 0.98, 0.01],
+                    [0.49, 0.02, 0.49],
+                ]
+            ]
+        ).log()
+
+        expected_output = torch.Tensor(
+            [[3.7361, 0.0]],
+        )
         output = ppo_trainer._kl_penalty(log_probs, ref_log_probs)
-        self.assertTrue(output.shape == (1,2))
+        self.assertTrue(output.shape == (1, 2))
         self.assertTrue(torch.allclose(output, expected_output, atol=1e-4))
-        
-        
-    
+
     @require_peft
     @mark.peft_test
     def test_peft_model_ppo_trainer(self):

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -719,7 +719,85 @@ class PPOTrainerTester(unittest.TestCase):
 
         expected_output = torch.Tensor([[0.0050, 0.0050, 0.0050], [0.0050, 0.0050, 0.0200]])
         self.assertTrue(torch.allclose(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
+        
+        
+    def test_ppo_trainer_full_kl_penalty(self):
+        # a few more extensive tests for the full kl option as it is more involved
+        dummy_dataset = self._init_dummy_dataset()
+        
+       
+        self.ppo_config.kl_penalty = "full"
+        ppo_trainer = PPOTrainer(
+            config=self.ppo_config,
+            model=self.gpt2_model,
+            ref_model=None,
+            tokenizer=self.gpt2_tokenizer,
+            dataset=dummy_dataset,
+        )
+        
+        # Test on tensors for size B,S,T = (1,2,3)
+        # test for when the two dists are the same
+        log_probs = torch.Tensor([   
+            [
+                [0.1, 0.2, 0.7],
+                [0.3, 0.4, 0.3],
+            ]
+        ]).exp()
 
+        ref_log_probs = torch.Tensor([   
+            [
+                [0.1, 0.2, 0.7],
+                [0.3, 0.4, 0.3],
+            ]
+        ]).exp()
+        
+        expected_output = torch.Tensor([[0.0, 0.0]],)
+        output = ppo_trainer._kl_penalty(log_probs, ref_log_probs)
+        self.assertTrue(output.shape == (1,2))
+        self.assertTrue(torch.allclose(output, expected_output))
+        
+        # test for when the two dists are almost not overlapping
+        log_probs = torch.Tensor([   
+            [
+                [0.98, 0.01, 0.01],
+                [0.01, 0.98, 0.01],
+            ]
+        ]).log()
+
+        ref_log_probs = torch.Tensor([   
+            [
+                [0.01,0.01,0.98],
+                [0.01,0.01,0.98],
+            ]
+        ]).log()
+        
+        expected_output = torch.Tensor([[4.4474, 4.4474]],)
+        output = ppo_trainer._kl_penalty(log_probs, ref_log_probs)
+        self.assertTrue(output.shape == (1,2))
+        self.assertTrue(torch.allclose(output, expected_output))
+        
+        # test for when the two dists are almost not overlapping
+        log_probs = torch.Tensor([   
+            [
+                [0.49, 0.02, 0.49],
+                [0.49, 0.02, 0.49],
+            ]
+        ]).log()
+
+        ref_log_probs = torch.Tensor([   
+            [
+                [0.01, 0.98, 0.01],
+                [0.49, 0.02, 0.49],
+            ]
+        ]).log()
+        
+        expected_output = torch.Tensor([[3.7361, 0.0]],)
+        output = ppo_trainer._kl_penalty(log_probs, ref_log_probs)
+        self.assertTrue(output.shape == (1,2))
+        self.assertTrue(torch.allclose(output, expected_output, atol=1e-4))
+        
+        
+    
     @require_peft
     @mark.peft_test
     def test_peft_model_ppo_trainer(self):

--- a/trl/core.py
+++ b/trl/core.py
@@ -93,9 +93,9 @@ def logprobs_from_logits(logits, labels, gather=True):
     See: https://github.com/pytorch/pytorch/issues/563#issuecomment-330103591
     """
     logp = F.log_softmax(logits, dim=2)
-    
+
     if not gather:
-        return logp 
+        return logp
     logpy = torch.gather(logp, 2, labels.unsqueeze(2)).squeeze(-1)
     return logpy
 

--- a/trl/core.py
+++ b/trl/core.py
@@ -88,11 +88,14 @@ def pad_to_size(tensor, size, dim=1, padding=50256):
         return torch.nn.functional.pad(tensor, (0, size - t_size), "constant", padding)
 
 
-def logprobs_from_logits(logits, labels):
+def logprobs_from_logits(logits, labels, gather=True):
     """
     See: https://github.com/pytorch/pytorch/issues/563#issuecomment-330103591
     """
     logp = F.log_softmax(logits, dim=2)
+    
+    if not gather:
+        return logp 
     logpy = torch.gather(logp, 2, labels.unsqueeze(2)).squeeze(-1)
     return logpy
 

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -80,7 +80,7 @@ class PPOConfig(object):
     kl_penalty: Optional[str] = field(
         default="kl",
         metadata={
-            "help": "kl penalty options: 'kl': model_logp - ref_logp,  'abs': abs(kl) and 'mse': mean squared error mse(kl)."
+            "help": "kl penalty options: 'kl': model_logp - ref_logp,  'abs': abs(kl),  'mse': mean squared error mse(kl) and 'full': the actual kl for all tokens in the distribution"
         },
     )
     target: Optional[float] = field(default=6, metadata={"help": "Target KL value for adaptive KL control"})

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -187,7 +187,7 @@ class PPOConfig(object):
                 )
 
         self.total_ppo_epochs = int(np.ceil(self.steps / self.batch_size))
-        assert self.kl_penalty in ["kl", "abs", "mse"]
+        assert self.kl_penalty in ["kl", "abs", "mse", "full"]
 
     def to_dict(self):
         output_dict = {}

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -662,8 +662,8 @@ class PPOTrainer(BaseTrainer):
         t = time.time()
 
         if full_kl_penalty:
-            active_full_logprobs = logprobs_from_logits(logits_or_none[:, :-1, :], None, gather=False)
-            ref_full_logprobs = logprobs_from_logits(ref_logits_or_none[:, :-1, :], None, gather=False)
+            active_full_logprobs = logprobs_from_logits(logits_or_none, None, gather=False)
+            ref_full_logprobs = logprobs_from_logits(ref_logits_or_none, None, gather=False)
 
             rewards, non_score_reward = self.compute_rewards(scores, active_full_logprobs, ref_full_logprobs, masks)
         else:

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -631,7 +631,7 @@ class PPOTrainer(BaseTrainer):
 
         model_inputs_names = list(model_inputs.keys())
 
-        full_kl_penalty = self.config.kl_penalty == "all"
+        full_kl_penalty = self.config.kl_penalty == "full"
 
         with torch.no_grad():
             all_logprobs, logits_or_none, values, masks = self.batched_forward_pass(

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -631,10 +631,12 @@ class PPOTrainer(BaseTrainer):
 
         model_inputs_names = list(model_inputs.keys())
 
-        full_kl_penalty = self.config.kl_penalty=="all"
+        full_kl_penalty = self.config.kl_penalty == "all"
 
         with torch.no_grad():
-            all_logprobs, logits_or_none, values, masks = self.batched_forward_pass(self.model, queries, responses, model_inputs, return_logits=full_kl_penalty)
+            all_logprobs, logits_or_none, values, masks = self.batched_forward_pass(
+                self.model, queries, responses, model_inputs, return_logits=full_kl_penalty
+            )
 
             # for when the model is a peft model
             if self.is_peft_model and hasattr(
@@ -642,23 +644,27 @@ class PPOTrainer(BaseTrainer):
                 "disable_adapter",
             ):
                 with self.accelerator.unwrap_model(self.model).pretrained_model.disable_adapter():
-                    ref_logprobs, ref_logits_or_none, _, _ = self.batched_forward_pass(self.model, queries, responses, model_inputs, return_logits=full_kl_penalty)
+                    ref_logprobs, ref_logits_or_none, _, _ = self.batched_forward_pass(
+                        self.model, queries, responses, model_inputs, return_logits=full_kl_penalty
+                    )
             elif self.is_peft_model and not hasattr(self.model.pretrained_model, "disable_adapter"):
                 raise ValueError(
                     "You are using a `peft` version that does not support `disable_adapter`. Please update your `peft` version to the latest version."
                 )
 
             else:
-                ref_logprobs, ref_logits_or_none, _, _ = self.batched_forward_pass(self.ref_model, queries, responses, model_inputs, return_logits=full_kl_penalty)
+                ref_logprobs, ref_logits_or_none, _, _ = self.batched_forward_pass(
+                    self.ref_model, queries, responses, model_inputs, return_logits=full_kl_penalty
+                )
 
         timing["time/ppo/forward_pass"] = time.time() - t
 
         t = time.time()
-        
+
         if full_kl_penalty:
             active_full_logprobs = logprobs_from_logits(logits_or_none[:, :-1, :], None, gather=False)
             ref_full_logprobs = logprobs_from_logits(ref_logits_or_none[:, :-1, :], None, gather=False)
-            
+
             rewards, non_score_reward = self.compute_rewards(scores, active_full_logprobs, ref_full_logprobs, masks)
         else:
             rewards, non_score_reward = self.compute_rewards(scores, all_logprobs, ref_logprobs, masks)
@@ -1027,10 +1033,10 @@ class PPOTrainer(BaseTrainer):
 
         if self.config.kl_penalty == "mse":
             return 0.5 * (logprob - ref_logprob).square()
-        
+
         if self.config.kl_penalty == "full":
             # Flip is required due to this issue? :https://github.com/pytorch/pytorch/issues/57459
-            return F.kl_div(ref_logprob, logprob,  log_target=True, reduction='none').sum(-1) 
+            return F.kl_div(ref_logprob, logprob, log_target=True, reduction="none").sum(-1)
 
         raise NotImplementedError
 

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -1029,7 +1029,8 @@ class PPOTrainer(BaseTrainer):
             return 0.5 * (logprob - ref_logprob).square()
         
         if self.config.kl_penalty == "full":
-            return F.kl_div(logprob, ref_logprob, log_target=True, reduction='none').sum(-1)
+            # Flip is required due to this issue? :https://github.com/pytorch/pytorch/issues/57459
+            return F.kl_div(ref_logprob, logprob,  log_target=True, reduction='none').sum(-1) 
 
         raise NotImplementedError
 


### PR DESCRIPTION
I got so fed up with negative KL that I have added an option to calculate the KL for the entire distribution. 
It is memory intensive for large sequences with an allocation of `8*vocab_size` per token, but it should stabilize training and cannot be negative! Memory usage could be greatly reduced but would require a larger refactor.

Single seed runs for gpt2-sentiment:

![image](https://github.com/lvwerra/trl/assets/7275864/436dfab0-531c-46a8-a494-c6913308bb0b)
