### PR TITLE
ADD: num_proc to SFTTrainer

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -89,7 +89,7 @@ class SFTTrainer(Trainer):
         packing (`Optional[bool]`):
             Used only in case `dataset_text_field` is passed. This argument is used by the `ConstantLengthDataset` to pack the sequences
             of the dataset.
-        num_proc (`Optional[int]`):
+        dataset_num_proc (`Optional[int]`):
             The number of workers to use to tokenize the data. Only used when `packing=False`. Defaults to None.
     """
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -294,7 +294,7 @@ class SFTTrainer(Trainer):
             return {"input_ids": outputs["input_ids"], "attention_mask": outputs["attention_mask"]}
 
         tokenized_dataset = dataset.map(
-            tokenize, batched=True, remove_columns=dataset.column_names, num_proc=self.num_proc
+            tokenize, batched=True, remove_columns=dataset.column_names, num_proc=self.dataset_num_proc
         )
 
         return tokenized_dataset

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -92,8 +92,8 @@ class SFTTrainer(Trainer):
         dataset_num_proc (`Optional[int]`):
             The number of workers to use to tokenize the data. Only used when `packing=False`. Defaults to None.
         dataset_batch_size (`int`):
-            Number of examples per batch provided to tokenize. If batch_size <= 0 or batch_size == None,
-             provide the full dataset as a single batch to tokenize. Defaults to 1000
+            The number of examples to tokenize per batch. If batch_size <= 0 or batch_size == None,
+            tokenize the full dataset as a single batch. Defaults to 1000.
     """
 
     def __init__(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -293,7 +293,8 @@ class SFTTrainer(Trainer):
 
             return {"input_ids": outputs["input_ids"], "attention_mask": outputs["attention_mask"]}
 
-        tokenized_dataset = dataset.map(tokenize, batched=True, remove_columns=dataset.column_names,
-                                        num_proc=self.num_proc)
+        tokenized_dataset = dataset.map(
+            tokenize, batched=True, remove_columns=dataset.column_names, num_proc=self.num_proc
+        )
 
         return tokenized_dataset

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -91,6 +91,9 @@ class SFTTrainer(Trainer):
             of the dataset.
         dataset_num_proc (`Optional[int]`):
             The number of workers to use to tokenize the data. Only used when `packing=False`. Defaults to None.
+        dataset_batch_size (`int`):
+            Number of examples per batch provided to tokenize. If batch_size <= 0 or batch_size == None,
+             provide the full dataset as a single batch to tokenize. Defaults to 1000
     """
 
     def __init__(
@@ -115,6 +118,7 @@ class SFTTrainer(Trainer):
         num_of_sequences: Optional[int] = 1024,
         chars_per_token: Optional[float] = 3.6,
         dataset_num_proc: Optional[int] = None,
+        dataset_batch_size: int = 1000,
     ):
         if isinstance(model, str):
             warnings.warn(
@@ -164,6 +168,7 @@ class SFTTrainer(Trainer):
             )
 
         self.dataset_num_proc = dataset_num_proc
+        self.dataset_batch_size = dataset_batch_size
         if not packing:
             if dataset_text_field is None and formatting_func is None:
                 raise ValueError(
@@ -294,7 +299,11 @@ class SFTTrainer(Trainer):
             return {"input_ids": outputs["input_ids"], "attention_mask": outputs["attention_mask"]}
 
         tokenized_dataset = dataset.map(
-            tokenize, batched=True, remove_columns=dataset.column_names, num_proc=self.dataset_num_proc
+            tokenize,
+            batched=True,
+            remove_columns=dataset.column_names,
+            num_proc=self.dataset_num_proc,
+            batch_size=self.dataset_batch_size,
         )
 
         return tokenized_dataset

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -114,7 +114,7 @@ class SFTTrainer(Trainer):
         infinite: Optional[bool] = False,
         num_of_sequences: Optional[int] = 1024,
         chars_per_token: Optional[float] = 3.6,
-        num_proc: Optional[int] = None,
+        dataset_num_proc: Optional[int] = None,
     ):
         if isinstance(model, str):
             warnings.warn(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -89,6 +89,8 @@ class SFTTrainer(Trainer):
         packing (`Optional[bool]`):
             Used only in case `dataset_text_field` is passed. This argument is used by the `ConstantLengthDataset` to pack the sequences
             of the dataset.
+        num_proc (`Optional[int]`):
+            The number of workers to use to tokenize the data. Only used when `packing=False`. Defaults to None.
     """
 
     def __init__(
@@ -112,6 +114,7 @@ class SFTTrainer(Trainer):
         infinite: Optional[bool] = False,
         num_of_sequences: Optional[int] = 1024,
         chars_per_token: Optional[float] = 3.6,
+        num_proc: Optional[int] = None,
     ):
         if isinstance(model, str):
             warnings.warn(
@@ -160,6 +163,7 @@ class SFTTrainer(Trainer):
                 f"You didn't pass a `max_seq_length` argument to the SFTTrainer, this will default to {max_seq_length}"
             )
 
+        self.num_proc = num_proc
         if not packing:
             if dataset_text_field is None and formatting_func is None:
                 raise ValueError(
@@ -289,6 +293,7 @@ class SFTTrainer(Trainer):
 
             return {"input_ids": outputs["input_ids"], "attention_mask": outputs["attention_mask"]}
 
-        tokenized_dataset = dataset.map(tokenize, batched=True, remove_columns=dataset.column_names)
+        tokenized_dataset = dataset.map(tokenize, batched=True, remove_columns=dataset.column_names,
+                                        num_proc=self.num_proc)
 
         return tokenized_dataset

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -163,7 +163,7 @@ class SFTTrainer(Trainer):
                 f"You didn't pass a `max_seq_length` argument to the SFTTrainer, this will default to {max_seq_length}"
             )
 
-        self.num_proc = num_proc
+        self.dataset_num_proc = dataset_num_proc
         if not packing:
             if dataset_text_field is None and formatting_func is None:
                 raise ValueError(


### PR DESCRIPTION
This tiny PR adds the optional argument `num_proc` to the SFTTrainer so that the mapped tokenization can occur in parallel if the user wishes that.