### PR TITLE
[`SFTTrainer`] Add warning for wrong padding_side

### DIFF
--- a/examples/scripts/sft_trainer.py
+++ b/examples/scripts/sft_trainer.py
@@ -65,14 +65,11 @@ if script_args.load_in_8bit and script_args.load_in_4bit:
     raise ValueError("You can't load the model in 8 bits and 4 bits at the same time")
 elif script_args.load_in_8bit or script_args.load_in_4bit:
     quantization_config = BitsAndBytesConfig(
-        load_in_8bit=script_args.load_in_8bit,
-        load_in_4bit=script_args.load_in_4bit,
-        bnb_4bit_quant_type="nf4",
-        bnb_4bit_compute_dtype=torch.float32,
+        load_in_8bit=script_args.load_in_8bit, load_in_4bit=script_args.load_in_4bit
     )
     # This means: fit the entire model on the GPU:0
     device_map = {"": 0}
-    torch_dtype = torch.float32
+    torch_dtype = torch.bfloat16
 else:
     device_map = None
     quantization_config = None
@@ -97,7 +94,6 @@ training_args = TrainingArguments(
     gradient_accumulation_steps=script_args.gradient_accumulation_steps,
     learning_rate=script_args.learning_rate,
     logging_steps=script_args.logging_steps,
-    optim="paged_adamw_32bit",
 )
 
 # Step 4: Define the LoraConfig
@@ -119,9 +115,5 @@ trainer = SFTTrainer(
     dataset_text_field=script_args.dataset_text_field,
     peft_config=peft_config,
 )
-
-for name, module in trainer.model.named_modules():
-    if "norm" in name:
-        module = module.to(torch.float32)
 
 trainer.train()

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -203,6 +203,12 @@ class SFTTrainer(Trainer):
                 chars_per_token,
             )
 
+        if tokenizer.padding_side is not None and tokenizer.padding != "right":
+            warnings.warn(
+                "You passed a tokenizer with `padding_side` not equal to `right` to the SFTTrainer. This might lead to some unexpected behaviour due to "
+                "overflow issues when training a model in half-precision. You might consider adding `tokenizer.padding_side = 'right'` to your code."
+            )
+
         super().__init__(
             model=model,
             args=args,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -203,7 +203,7 @@ class SFTTrainer(Trainer):
                 chars_per_token,
             )
 
-        if tokenizer.padding_side is not None and tokenizer.padding != "right":
+        if tokenizer.padding_side is not None and tokenizer.padding_side != "right":
             warnings.warn(
                 "You passed a tokenizer with `padding_side` not equal to `right` to the SFTTrainer. This might lead to some unexpected behaviour due to "
                 "overflow issues when training a model in half-precision. You might consider adding `tokenizer.padding_side = 'right'` to your code."


### PR DESCRIPTION
While debugging why some users got 0 loss when fine-tuning Llama-2 on Guanaco, it seems the issue was caused by padding tokens being appended on the left. 

The fix for that model seems to be to force `tokenizer.padding_side = "right"` to successfully fine-tune Llama-2. Therefore we advise users to do that for their training. 

Related: https://gist.github.com/younesbelkada/9f7f75c94bdc1981c8ca5cc937d4a4da?permalink_comment_id=4636728#gistcomment-4636728

cc @lvwerra 