### PR TITLE
Minor typo and whitespace fixes

### DIFF
--- a/docs/source/lora_tuning_peft.mdx
+++ b/docs/source/lora_tuning_peft.mdx
@@ -135,7 +135,7 @@ Although `trl` library is powered by `accelerate`, you should run your training 
 python PATH_TO_SCRIPT
 ```
 
-## Fine-tuning Llama-2 model 
+## Fine-tuning Llama-2 model
 
 You can easily fine-tune Llama2 model using `SFTTrainer` and the official script! For example to fine-tune llama2-7b on the Guanaco dataset, run (tested on a single NVIDIA T4-16GB):
 

--- a/examples/scripts/sft_trainer.py
+++ b/examples/scripts/sft_trainer.py
@@ -36,7 +36,7 @@ class ScriptArguments:
 
     model_name: Optional[str] = field(default="facebook/opt-350m", metadata={"help": "the model name"})
     dataset_name: Optional[str] = field(
-        default="timdettmers/openassistant-guanaco", metadata={"help": "the model name"}
+        default="timdettmers/openassistant-guanaco", metadata={"help": "the dataset name"}
     )
     dataset_text_field: Optional[str] = field(default="text", metadata={"help": "the text field of the dataset"})
     log_with: Optional[str] = field(default=None, metadata={"help": "use 'wandb' to log with wandb"})


### PR DESCRIPTION
Just some small things I noticed while reading the docs and examples