### PR TITLE
[distributed training] conditional statement error for GPU allocation

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -331,7 +331,7 @@ class PPOTrainer(BaseTrainer):
             self.highest_reward = torch.tensor(-float("inf"))
 
         # post process for PP
-        if not getattr(self.model, "is_sequential_parallel", False):
+        if getattr(self.model, "is_sequential_parallel", False):
             self.current_device = self.accelerator.device
         else:
             self.current_device = torch.device("cuda:0")


### PR DESCRIPTION
should remove `not`
'''
        if not getattr(self.model, "is_sequential_parallel", False):
            self.current_device = self.accelerator.device
        else:
            self.current_device = torch.device("cuda:0")
'''