### PR TITLE
Add missing max_seq_length arg to example sft_trainer.py

### DIFF
--- a/examples/scripts/sft_trainer.py
+++ b/examples/scripts/sft_trainer.py
@@ -115,6 +115,7 @@ else:
 trainer = SFTTrainer(
     model=model,
     args=training_args,
+    max_seq_length=script_args.seq_length,
     train_dataset=dataset,
     dataset_text_field=script_args.dataset_text_field,
     peft_config=peft_config,


### PR DESCRIPTION
I believe this was supposed to be here already, as the `--seq_length` argument doesn't currently seem to be getting used, and there is no other way I can see to set max_seq_length.
I may be mistaken though, I'm not familiar with the code yet.