### PR TITLE
docs: Replace SFTTrainer with RewardTrainer in comment

### DIFF
--- a/examples/scripts/reward_trainer.py
+++ b/examples/scripts/reward_trainer.py
@@ -36,7 +36,7 @@ tqdm.pandas()
 @dataclass
 class ScriptArguments:
     """
-    The name of the Casual LM model we wish to fine with SFTTrainer
+    The name of the Casual LM model we wish to fine with RewardTrainer
     """
 
     model_name: Optional[str] = field(default="facebook/opt-350m", metadata={"help": "the model name"})


### PR DESCRIPTION
Hello!

## Pull Request overview
* Replace `SFTTrainer` with `RewardTrainer` in a comment in `reward_trainer.py`.

## Details
It was likely just a copy-paste error - this speaks for itself.

We can also just refactor this comment (and the one from `sft_trainer.py`), as they don't make much sense.

---

- Tom Aarsen