### PR TITLE
Fix comparison in DataCollatorForCompletionOnlyLM (#588)

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import os
 import tempfile
 import unittest
@@ -422,6 +423,29 @@ class SFTTrainerTester(unittest.TestCase):
         result_text = self.tokenizer.decode(batch["input_ids"][0, last_pad_idx + 1 :])
         self.assertEqual(result_text, "I have not been masked correctly.")
 
+    def test_data_collator_completion_lm_with_multiple_text(self):
+        tokenizer = copy.deepcopy(self.tokenizer)
+        tokenizer.padding_side = "left"
+
+        response_template = "### Response:\n"
+        data_collator = DataCollatorForCompletionOnlyLM(response_template, tokenizer=tokenizer, mlm=False)
+
+        text1 = """\n\n### Instructions:\nHello all this should be masked\n\n### Response:\nI have not been masked correctly."""
+        text2 = """\n\n### Instructions:\nThis is another longer text that should also be masked. This text is significantly longer than the previous one.\n\n### Response:\nI have not been masked correctly."""
+
+        encoded_text1 = tokenizer(text1)
+        encoded_text2 = tokenizer(text2)
+
+        examples = [encoded_text1, encoded_text2]
+
+        batch = data_collator(examples)
+
+        for i in range(2):
+            labels = batch["labels"][i]
+            last_pad_idx = np.where(labels == -100)[0][-1]
+            result_text = tokenizer.decode(batch["input_ids"][i, last_pad_idx + 1 :])
+            self.assertEqual(result_text, "I have not been masked correctly.")
+
     def test_data_collator_chat_completion_lm(self):
         instruction_template = "### Human:"
         assistant_template = "### Assistant:"
@@ -442,6 +466,38 @@ class SFTTrainerTester(unittest.TestCase):
         non_masked_tokens = batch["input_ids"][labels != -100]
         result_text = self.tokenizer.decode(non_masked_tokens)
         self.assertEqual(result_text, " I should not be masked. I should not be masked too.")
+
+    def test_data_collator_chat_completion_lm_with_multiple_text(self):
+        tokenizer = copy.deepcopy(self.tokenizer)
+        tokenizer.padding_side = "left"
+
+        instruction_template = "### Human:"
+        assistant_template = "### Assistant:"
+        data_collator = DataCollatorForCompletionOnlyLM(
+            response_template=assistant_template,
+            instruction_template=instruction_template,
+            tokenizer=tokenizer,
+            mlm=False,
+        )
+
+        text1 = """### Human: Hello all this should be masked.### Assistant: I should not be masked."""
+        text2 = """### Human: Hello all this should be masked.### Assistant: I should not be masked.### Human: All this should be masked too.### Assistant: I should not be masked too."""
+        encoded_text1 = tokenizer(text1)
+        encoded_text2 = tokenizer(text2)
+
+        examples = [encoded_text1, encoded_text2]
+
+        batch = data_collator(examples)
+        labels = batch["labels"]
+        input_ids = batch["input_ids"]
+
+        non_masked_tokens1 = input_ids[0][labels[0] != -100]
+        result_text1 = tokenizer.decode(non_masked_tokens1)
+        self.assertEqual(result_text1, " I should not be masked.")
+
+        non_masked_tokens2 = input_ids[1][labels[1] != -100]
+        result_text2 = tokenizer.decode(non_masked_tokens2)
+        self.assertEqual(result_text2, " I should not be masked. I should not be masked too.")
 
     def test_sft_trainer_infinite_with_model(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -94,7 +94,10 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
 
                 for idx in np.where(batch["labels"][i] == self.response_token_ids[0])[0]:
                     # `response_token_ids` is `'### Response:\n'`, here we are just making sure that the token IDs match
-                    if self.response_token_ids == examples[i]["input_ids"][idx : idx + len(self.response_token_ids)]:
+                    if (
+                        self.response_token_ids
+                        == batch["labels"][i][idx : idx + len(self.response_token_ids)].tolist()
+                    ):
                         response_token_ids_start_idx = idx
 
                 if response_token_ids_start_idx is None:
@@ -116,7 +119,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                     # find the indexes of the start of a response.
                     if (
                         self.response_token_ids
-                        == examples[i]["input_ids"][assistant_idx : assistant_idx + len(self.response_token_ids)]
+                        == batch["labels"][i][assistant_idx : assistant_idx + len(self.response_token_ids)].tolist()
                     ):
                         response_token_ids_idxs.append(assistant_idx + len(self.response_token_ids))
 
@@ -128,7 +131,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                 human_token_ids = self.tokenizer.encode(self.instruction_template, add_special_tokens=False)
                 for human_idx in np.where(batch["labels"][i] == human_token_ids[0])[0]:
                     # find the indexes of the start of a human answer.
-                    if human_token_ids == examples[i]["input_ids"][human_idx : human_idx + len(human_token_ids)]:
+                    if human_token_ids == batch["labels"][i][human_idx : human_idx + len(human_token_ids)].tolist():
                         human_token_ids_idxs.append(human_idx)
 
                 if len(human_token_ids_idxs) == 0:


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/lvwerra/trl/issues/588

This PR fixes issue https://github.com/lvwerra/trl/issues/588 encountered in the DataCollatorForCompletionOnlyLM class. Originally, the class compared self.response_token_ids with examples[i]["input_ids"], which caused a RuntimeError under certain circumstances.

This PR changes the comparison target to batch["labels"][i] from examples[i]["input_ids"] and add unit tests.
The added unit test reproduces the bug reported in the issue. Additionally, I have confirmed that the changes I made cause the added unit test to pass.

## Before submitting
- [x] `make precommit`
- [x] Add tests

Please review and let me know if any changes are required.