### PR TITLE
Use `accelerate` to clip gradient norm

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -982,7 +982,7 @@ class PPOTrainer(BaseTrainer):
         self.accelerator.backward(loss)
 
         if self.config.max_grad_norm is not None:
-            torch.nn.utils.clip_grad_norm_(
+            self.accelerator.clip_grad_norm_(
                 filter(lambda p: p.requires_grad, self.model.parameters()),
                 self.config.max_grad_norm,
             )


### PR DESCRIPTION
Follows best practice here: https://huggingface.co/docs/accelerate/v0.1.0/accelerator.html.

Should only really make a difference in case accelerator uses the following:
```python
 if self.state.use_fp16 and self.native_amp
```