### PR TITLE
Use log_with argument in SFT example

### DIFF
--- a/examples/scripts/sft_trainer.py
+++ b/examples/scripts/sft_trainer.py
@@ -98,6 +98,7 @@ training_args = TrainingArguments(
     logging_steps=script_args.logging_steps,
     num_train_epochs=script_args.num_train_epochs,
     max_steps=script_args.max_steps,
+    report_to=script_args.log_with,
 )
 
 # Step 4: Define the LoraConfig


### PR DESCRIPTION
It's in the script arguments, but not used

```
log_with: Optional[str] = field(default=None, metadata={"help": "use 'wandb' to log with wandb"})
```