### PR TITLE
Allow already tokenized sequences for `response_template` in `DataCollatorForCompletionOnlyLM`

### DIFF
--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -52,8 +52,8 @@ The above snippets will use the default training arguments from the [`transforme
 
 ### Train on completions only 
 
-To instantiate that collator for instruction data, pass a response template and the tokenizer. Here is an example of how it would work to fine-tune `opt-350m` on completions only on the CodeAlpaca dataset:
 You can use the `DataCollatorForCompletionOnlyLM` to train your model on the generated prompts only. Note that this works only in the case when `packing=False`.
+To instantiate that collator for instruction data, pass a response template and the tokenizer. Here is an example of how it would work to fine-tune `opt-350m` on completions only on the CodeAlpaca dataset:
 
 ```python
 from transformers import AutoModelForCausalLM, AutoTokenizer

--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -52,8 +52,8 @@ The above snippets will use the default training arguments from the [`transforme
 
 ### Train on completions only 
 
-You can use the `DataCollatorForCompletionOnlyLM` to train your model on the generated prompts only. Note that this works only in the case when `packing=False`.
 To instantiate that collator for instruction data, pass a response template and the tokenizer. Here is an example of how it would work to fine-tune `opt-350m` on completions only on the CodeAlpaca dataset:
+You can use the `DataCollatorForCompletionOnlyLM` to train your model on the generated prompts only. Note that this works only in the case when `packing=False`.
 
 ```python
 from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -109,6 +109,47 @@ trainer = SFTTrainer(
 )
 
 trainer.train() 
+```
+
+#### Using token_ids directly for `response_template`
+
+Some tokenizers like Llama 2 (`meta-llama/Llama-2-XXb-hf`) tokenize sequences differently depending whether they have context or not. For example:
+    
+```python
+from transformers import AutoTokenizer
+tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
+
+def print_tokens_with_ids(txt):
+    tokens = tokenizer.tokenize(txt, add_special_tokens=False)
+    token_ids = tokenizer.encode(txt, add_special_tokens=False)
+    print(list(zip(tokens, token_ids)))
+
+prompt = """### User: Hello\n\n### Assistant: Hi, how can I help you?"""
+print_tokens_with_ids(prompt)  # [..., ('▁Hello', 15043), ('<0x0A>', 13), ('<0x0A>', 13), ('##', 2277), ('#', 29937), ('▁Ass', 4007), ('istant', 22137), (':', 29901), ...]
+
+response_template = "### Assistant:"
+print_tokens_with_ids(response_template)  # [('▁###', 835), ('▁Ass', 4007), ('istant', 22137), (':', 29901)]
+```
+
+In this case, and due to lack of context in `response_template`, the same string ("### Assistant:") is tokenized differently:
+    
+    - Text (with context): `[2277, 29937, 4007, 22137, 29901]`
+    - `response_template` (without context): `[835, 4007, 22137, 29901]`
+
+This will lead to an error when the `DataCollatorForCompletionOnlyLM` does not find the `response_template` in the dataset example text:
+
+```
+RuntimeError: Could not find response key [835, 4007, 22137, 29901] in token IDs tensor([    1,   835,  ...])   
+```
+
+
+To solve this, you can tokenize the `response_template` with the same context than in the dataset, truncate it as needed and pass the `token_ids` directly to the `response_template` argument of the `DataCollatorForCompletionOnlyLM` class. For example:
+
+```python
+response_template_with_context = "\n### Assistant:"  # We added context here: "\n". This is enough for this tokenizer
+response_template_ids = tokenizer.encode(response_template_with_context, add_special_tokens=False)[2:]  # Now we have it like in the dataset texts: `[2277, 29937, 4007, 22137, 29901]`
+
+data_collator = DataCollatorForCompletionOnlyLM(response_template_ids, tokenizer=tokenizer)
 ```
 
 ### Format your input prompts

--- a/tests/test_data_collator_completion_only.py
+++ b/tests/test_data_collator_completion_only.py
@@ -13,17 +13,16 @@
 # limitations under the License.
 import unittest
 
-import pandas as pd
-import pyarrow
-from datasets import Dataset, DatasetDict
 from transformers import AutoTokenizer
 
-from trl import DataCollatorForCompletionOnlyLM, SFTTrainer
+from trl import DataCollatorForCompletionOnlyLM
 
 
 class DataCollatorForCompletionOnlyLMTester(unittest.TestCase):
     def test_data_collator_finds_response_template_llama2_tokenizer(self):
-        self.tokenizer = AutoTokenizer.from_pretrained("upstage/Llama-2-70b-instruct-v2")  # Not using official one to avoid logging in
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            "upstage/Llama-2-70b-instruct-v2"
+        )  # Not using official one to avoid logging in
         self.instruction = """### System: You are a helpful assistant.
 
 ### User: How much is 2+2?
@@ -31,25 +30,24 @@ class DataCollatorForCompletionOnlyLMTester(unittest.TestCase):
 ### Assistant: 2+2 equals 4"""
         self.response_template = "\n### Assistant:"
         # [29871, 13, 2277, 29937, 4007, 22137, 29901] -> [2277, 29937, 4007, 22137, 29901]
-        self.tokenized_response_w_context = self.tokenizer.encode(
-            self.response_template,
-            add_special_tokens=False
-        )[2:]
+        self.tokenized_response_w_context = self.tokenizer.encode(self.response_template, add_special_tokens=False)[2:]
 
         # Plain check on string
         self.assertIn(self.response_template, self.instruction)
         self.tokenized_instruction = self.tokenizer.encode(self.instruction, add_special_tokens=False)
-        
+
         # Test the fix for #598
         # Pass already tokenized (w context) and truncated response_template so token_ids are like in the instruction
         self.collator = DataCollatorForCompletionOnlyLM(self.tokenized_response_w_context, tokenizer=self.tokenizer)
 
         # Check with tokenizer (like a regular call from Trained would do)
         def print_tokenize(txt):
-            for x in list(zip(
+            for x in list(
+                zip(
                     self.tokenizer.tokenize(txt, add_special_tokens=False),
-                    self.tokenizer.encode(txt, add_special_tokens=False)
-                )):
+                    self.tokenizer.encode(txt, add_special_tokens=False),
+                )
+            ):
                 print(x)
 
         # import pdb; pdb.set_trace()

--- a/tests/test_data_collator_completion_only.py
+++ b/tests/test_data_collator_completion_only.py
@@ -37,18 +37,6 @@ class DataCollatorForCompletionOnlyLMTester(unittest.TestCase):
         self.tokenized_instruction = self.tokenizer.encode(self.instruction, add_special_tokens=False)
 
         # Test the fix for #598
-        # Pass already tokenized (w context) and truncated response_template so token_ids are like in the instruction
+        # Pass already tokenized (w context) and truncated response_template so token_ids are like in the instruction + response
         self.collator = DataCollatorForCompletionOnlyLM(self.tokenized_response_w_context, tokenizer=self.tokenizer)
-
-        # Check with tokenizer (like a regular call from Trained would do)
-        def print_tokenize(txt):
-            for x in list(
-                zip(
-                    self.tokenizer.tokenize(txt, add_special_tokens=False),
-                    self.tokenizer.encode(txt, add_special_tokens=False),
-                )
-            ):
-                print(x)
-
-        # import pdb; pdb.set_trace()
         self.collator.torch_call([self.tokenized_instruction])

--- a/tests/test_data_collator_completion_only.py
+++ b/tests/test_data_collator_completion_only.py
@@ -1,0 +1,56 @@
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import pandas as pd
+import pyarrow
+from datasets import Dataset, DatasetDict
+from transformers import AutoTokenizer
+
+from trl import DataCollatorForCompletionOnlyLM, SFTTrainer
+
+
+class DataCollatorForCompletionOnlyLMTester(unittest.TestCase):
+    def test_data_collator_finds_response_template_llama2_tokenizer(self):
+        self.tokenizer = AutoTokenizer.from_pretrained("upstage/Llama-2-70b-instruct-v2")  # Not using official one to avoid logging in
+        self.instruction = """### System: You are a helpful assistant.
+
+### User: How much is 2+2?
+
+### Assistant: 2+2 equals 4"""
+        self.response_template = "\n### Assistant:"
+        # [29871, 13, 2277, 29937, 4007, 22137, 29901] -> [2277, 29937, 4007, 22137, 29901]
+        self.tokenized_response_w_context = self.tokenizer.encode(
+            self.response_template,
+            add_special_tokens=False
+        )[2:]
+
+        # Plain check on string
+        self.assertIn(self.response_template, self.instruction)
+        self.tokenized_instruction = self.tokenizer.encode(self.instruction, add_special_tokens=False)
+        
+        # Test the fix for #598
+        # Pass already tokenized (w context) and truncated response_template so token_ids are like in the instruction
+        self.collator = DataCollatorForCompletionOnlyLM(self.tokenized_response_w_context, tokenizer=self.tokenizer)
+
+        # Check with tokenizer (like a regular call from Trained would do)
+        def print_tokenize(txt):
+            for x in list(zip(
+                    self.tokenizer.tokenize(txt, add_special_tokens=False),
+                    self.tokenizer.encode(txt, add_special_tokens=False)
+                )):
+                print(x)
+
+        # import pdb; pdb.set_trace()
+        self.collator.torch_call([self.tokenized_instruction])


### PR DESCRIPTION
This PR fixes issue described in https://github.com/lvwerra/trl/issues/598

# Problem

Some tokenizers will tokenize the same string differently, depending on whether it has left context or not. An example of this is the tokenizer of `meta-llama/Llama-2-7b-hf`, that tokenizes the `response_template` differently in these cases:

```python
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")

def print_tokens_with_ids(txt):
    tokens = tokenizer.tokenize(txt, add_special_tokens=False)
    token_ids = tokenizer.encode(txt, add_special_tokens=False)
    print(list(zip(tokens, token_ids)))

prompt = """### User: Hello\n\n### Assistant: Hi, how can I help you?"""
print_tokens_with_ids(prompt)  # [..., ('▁Hello', 15043), ('<0x0A>', 13), ('<0x0A>', 13), ('##', 2277), ('#', 29937), ('▁Ass', 4007), ('istant', 22137), (':', 29901), ...]

response_template = "### Assistant:"
print_tokens_with_ids(response_template)  # [('▁###', 835), ('▁Ass', 4007), ('istant', 22137), (':', 29901)]
```

This leads to an error when the instanced data_collator `DataCollatorForCompletionOnlyLM` tries to look for the response_template in the text of the instruction dataset, because it does not find it.


# Solution

Allow `response_template` in `DataCollatorForCompletionOnlyLM` to use directly `token_ids` that are prepared with enough context (and then sliced) to match how they appear in instruction datasets, where they have the left context.

# Extra additions in the PR

I added a test to check the fix, for which I had to use a non-official tokenizer (`upstage/Llama-2-70b-instruct-v2` instead of `meta-llama/Llama-2-7b-hf`) because the official one needs to be logged in a huggingface account that has accepted the License and has been granted access to the tokenized, as described in the [model card](https://huggingface.co/meta-llama/Llama-2-7b-hf).

I also added a subsection in the documentation that explains the problem and how to solve it using the code fix that only works with this PR.